### PR TITLE
handles the case of NaN's being saved into the step counts

### DIFF
--- a/model/activity_avoidance.py
+++ b/model/activity_avoidance.py
@@ -249,7 +249,15 @@ class ActivityAvoidance:
         sum_before = self.step_counts[("baseline", "-")]
         sum_est = np.array(list(self.step_counts.values())).sum(axis=0)
         # create the slack to add to each step
-        slack = 1 + (sum_after - sum_est) / (sum_est - sum_before)
+        # note: simple division will cause an issue in the case that there is
+        #   no change, i.e. sum_est == sum_before. this ensures that if that is
+        #   the case, then we get a value of 1 for the slack
+        slack = 1 + np.divide(
+            sum_after - sum_est,
+            sum_est - sum_before,
+            out=np.zeros_like(sum_before),
+            where=sum_est != sum_before,
+        )
         for k in self.step_counts.keys():
             if k != ("baseline", "-"):
                 self.step_counts[k] *= slack


### PR DESCRIPTION
when there is no change to activity, the slack was being set to NaN, which
caused the entire results to fail to save properly

atleast, the results saved, but R couldn't process the json correctly

Fixes #75
