### PR TITLE
adds additional logging to docker container

### DIFF
--- a/docker_run.py
+++ b/docker_run.py
@@ -225,12 +225,17 @@ def main():
         datefmt="%Y-%m-%d %H:%M:%S",
     )
 
-    logging.info("running model for: %s", args.params_file)
-
     if args.local_storage:
         runner = RunWithLocalStorage(args.params_file)
     else:
         runner = RunWithAzureStorage(args.params_file, config.APP_VERSION)
+
+    logging.info("running model for: %s", args.params_file)
+    logging.info("submitted by: %s", runner.params.get("user"))
+    logging.info("model_runs:   %s", runner.params["model_runs"])
+    logging.info("start_year:   %s", runner.params["start_year"])
+    logging.info("end_year:     %s", runner.params["end_year"])
+    logging.info("app_version:  %s", runner.params["app_version"])
 
     results_file = run_all(
         runner.params, "data", runner.progress_callback, args.save_full_model_results

--- a/tests/test_docker_run.py
+++ b/tests/test_docker_run.py
@@ -380,7 +380,14 @@ def test_main_local(mocker):
     rwls = mocker.patch("docker_run.RunWithLocalStorage")
     rwas = mocker.patch("docker_run.RunWithAzureStorage")
 
-    rwls().params = "params"
+    params = {
+        "model_runs": 256,
+        "start_year": 2019,
+        "end_year": 2035,
+        "app_version": "dev",
+    }
+
+    rwls().params = params
     rwls.reset_mock()
 
     ru_m = mocker.patch("docker_run.run_all", return_value="results.json")
@@ -393,7 +400,7 @@ def test_main_local(mocker):
     rwas.assert_not_called()
 
     s = rwls()
-    ru_m.assert_called_once_with("params", "data", s.progress_callback, False)
+    ru_m.assert_called_once_with(params, "data", s.progress_callback, False)
     s.finish.assert_called_once_with("results.json", False)
 
 
@@ -407,7 +414,14 @@ def test_main_azure(mocker):
     rwls = mocker.patch("docker_run.RunWithLocalStorage")
     rwas = mocker.patch("docker_run.RunWithAzureStorage")
 
-    rwas().params = "params"
+    params = {
+        "model_runs": 256,
+        "start_year": 2019,
+        "end_year": 2035,
+        "app_version": "dev",
+    }
+
+    rwas().params = params
     rwas.reset_mock()
 
     ru_m = mocker.patch("docker_run.run_all", return_value="results.json")
@@ -420,7 +434,7 @@ def test_main_azure(mocker):
     rwas.assert_called_once_with("params.json", "dev")
 
     s = rwas()
-    ru_m.assert_called_once_with("params", "data", s.progress_callback, False)
+    ru_m.assert_called_once_with(params, "data", s.progress_callback, False)
     s.finish.assert_called_once_with("results.json", False)
 
 


### PR DESCRIPTION
currently it can be difficult to figure out in ACI who submitted a particular model run and any useful information that might help to debug, without downloading the parameters from the queue. This adds additional logging to quickly show this information.