### PR TITLE
general los in model

### DIFF
--- a/model/inpatients.py
+++ b/model/inpatients.py
@@ -115,6 +115,35 @@ class InpatientsModel(Model):
             k: load_fn(k) for k in ["activity_avoidance", "efficiencies"]
         }
 
+        def append_general_los(i, j):
+            j = f"general_los_reduction_{j}"
+            if j not in self.params["efficiencies"]["ip"]:
+                return None
+
+            return (
+                self.data.query(f"admimeth.str.startswith('{i}') & (speldur > 0)")
+                .set_index("rn")[[]]
+                .drop_duplicates()
+                .drop_duplicates()
+                .merge(
+                    self.strategies["efficiencies"],
+                    how="left",
+                    left_index=True,
+                    right_index=True,
+                    indicator=True,
+                )
+                .query("_merge != 'both'")
+                .drop(columns="_merge")
+                .fillna({"strategy": j, "sample_rate": 1.0})
+            )
+
+        # set admissions without a strategy selected to general_los_reduction_X
+        # where applicable
+        self.strategies["efficiencies"] = pd.concat(
+            [self.strategies["efficiencies"]]
+            + [append_general_los(*x) for x in [("1", "elective"), ("2", "emergency")]]
+        )
+
     def get_data_counts(self, data: pd.DataFrame) -> npt.ArrayLike:
         """Get row counts of data
 
@@ -407,17 +436,6 @@ class InpatientEfficiencies:
             )
             .rename(None)
         )
-        # set admissions without a strategy selected to general_los_reduction_X
-        # where applicable
-        for i, j in [("1", "elective"), ("2", "emergency")]:
-            j = f"general_los_reduction_{j}"
-            if j not in self._model_run.params["efficiencies"]["ip"]:
-                continue
-            selected_strategy[
-                self.data["admimeth"].str.startswith(i)
-                & (self.data["speldur"] > 0)
-                & selected_strategy.isna()
-            ] = j
         # assign the selected strategies
         self.data.set_index(selected_strategy, inplace=True)
 

--- a/tests/test_inpatient_efficiencies.py
+++ b/tests/test_inpatient_efficiencies.py
@@ -57,32 +57,19 @@ def test_init(mocker):
     actual._generate_losr_df.assert_called_once()
 
 
-@pytest.mark.parametrize(
-    "strategy, x",
-    [
-        ("general_los_reduction_emergency", True),
-        ("general_los_reduction_elective", False),
-    ],
-)
-def test_select_single_strategy(mock_ipe, strategy, x):
+def test_select_single_strategy(mock_ipe):
     # arrange
     m = mock_ipe
     m._model_run.rng = np.random.default_rng(0)
     m._model_run.data = pd.DataFrame(
-        {
-            "rn": list(range(9)),
-            "admimeth": ["0"] * 4 + ["3"] + ["2"] * 2 + ["1"] * 2,
-            "speldur": [0] * 5 + [0, 1] * 2,
-        }
+        {"rn": list(range(5)), "admimeth": ["0"] * 4 + ["3"]}
     )
     m._model_run.model.strategies = {
         "efficiencies": pd.DataFrame(
             {"strategy": ["a"] * 3 + ["b"] * 3}, index=[1, 2, 3] * 2
         )
     }
-    m._model_run.params = {
-        "efficiencies": {"ip": {"a": 2, "b": 3, "c": 4, strategy: 5}}
-    }
+    m._model_run.params = {"efficiencies": {"ip": {"a": 2, "b": 3, "c": 4}}}
 
     # act
     m._select_single_strategy()
@@ -94,7 +81,7 @@ def test_select_single_strategy(mock_ipe, strategy, x):
         "b",
         "a",
         "NULL",
-    ] + ["NULL", strategy if x else "NULL"] + ["NULL", strategy if not x else "NULL"]
+    ]
 
 
 def test_generate_losr_df(mock_ipe):


### PR DESCRIPTION
general LOS should only apply to rows which otherwise do not have a strategy applied to them.

this isn't possible to calculate before running the model, because it depends upon what mitigators the user provides values for.

we now figure out after assigning mitigators which rows to apply general los reduction t