### PR TITLE
keep model_runs for all aggregations

### DIFF
--- a/run_model.py
+++ b/run_model.py
@@ -132,10 +132,7 @@ def _split_model_runs_out(agg_type: str, results: dict) -> None:
         result["median"] = median
         result["upr_ci"] = upr
 
-        if agg_type != "default":
-            result.pop("model_runs")
-        else:
-            result["model_runs"] = [int(i) for i in result["model_runs"]]
+        result["model_runs"] = [int(i) for i in result["model_runs"]]
 
         result["baseline"] = int(result["baseline"])
         result["principal"] = int(result["principal"])

--- a/tests/test_run_model.py
+++ b/tests/test_run_model.py
@@ -245,7 +245,7 @@ def test_combine_results(mocker):
     assert m.call_args_list == [call(k, v) for k, v in expected.items()]
 
 
-def test_split_model_runs_out_default():
+def test_split_model_runs_out():
     # arrange
     results = [
         {
@@ -271,36 +271,6 @@ def test_split_model_runs_out_default():
 
     # act
     _split_model_runs_out("default", results)
-
-    # assert
-    assert results == expected
-
-
-def test_split_model_runs_out_other():
-    # arrange
-    results = [
-        {
-            "pod": "a",
-            "measure": "a",
-            "baseline": 1,
-            "principal": 2,
-            "model_runs": list(range(101)),
-        }
-    ]
-    expected = [
-        {
-            "pod": "a",
-            "measure": "a",
-            "baseline": 1,
-            "principal": 2,
-            "lwr_ci": 10.0,
-            "median": 50.0,
-            "upr_ci": 90.0,
-        }
-    ]
-
-    # act
-    _split_model_runs_out("other", results)
 
     # assert
     assert results == expected


### PR DESCRIPTION
previously we only kept the full model_runs values for the default aggretation. this change keeps the model_runs values for all aggregation types