### PR TITLE
updates download data scripts

### DIFF
--- a/download_data.ps1
+++ b/download_data.ps1
@@ -1,18 +1,19 @@
-param ($dataversion)
-$saname = 'nhpsa'
+param (
+  $dataversion = "dev",
+  $dataset = "synthetic",
+  $year = "2019"
+)
 
-if ($dataversion -eq $null) {
-  Write-Host "Missing argument: data version 
-}
+$saname = 'nhpsa'
 
 az storage blob download-batch `
   -d data `
-  --pattern "$($dataversion)/synthetic/*" `
+  --pattern "$dataversion/$year/$dataset/*" `
   -s data `
   --account-name nhpsa `
   --auth-mode login `
   --overwrite true
 
-rm -rf data/synthetic
-mv "data/$($dataversion)/synthetic" data
-rmdir "data/$($dataversion)"
+Remove-Item -Recurse -Force "data/$year/$dataset"
+Move-Item "data/$dataversion/$year/$dataset" "data/$year/$dataset"
+Remove-Item -Recurse -Force "data/$dataversion"

--- a/download_data.sh
+++ b/download_data.sh
@@ -4,20 +4,25 @@ set -eo pipefail
 
 export saname=nhpsa
 
-if [ $# -eq 0 ]
+if [ $# != 3 ]
 then
-  echo "Missing argument: data version"
+  echo "Missing arguments: data_version, dataset, year"
   exit
 fi
 
+data_version=$1
+dataset=$2
+year=$3
+data_path="$data_version/$year/$dataset"
+
 az storage blob download-batch \
   -d data \
-  --pattern "$1/synthetic/*" \
+  --pattern "$data_path/*" \
   -s data \
   --account-name nhpsa \
   --auth-mode login \
   --overwrite true
 
-rm -rf data/synthetic
-mv "data/$1/synthetic" data
-rmdir "data/$1"
+rm -rf "data/$year/$dataset"
+mv "data/$data_version/$year/$dataset" "data/$year/$dataset"
+rm -rf "data/$data_version"


### PR DESCRIPTION
fixes #177

alters the powershell/bash scripts to take 3 arguments, these allow you to choose the dataset (e.g. synthetic), the year (e.g. 2019) and the data version (e.g. dev) to download from.