### PR TITLE
switches to copy from add to ensure user owns files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ COPY docker_run.py /opt
 COPY config.py /opt
 
 # copy reference data
-ADD data/reference data/reference
+COPY --chown=$MAMBA_USER:$MAMBA_USER data/reference data/reference
 
 # define build arguments, these will set the environment variables in the container
 ARG app_version


### PR DESCRIPTION
a minor fix to ensure that when the reference data files are copied into the container, they are owned by the user which runs the model code, and not root