### PR TITLE
add regular attender pods

### DIFF
--- a/model/inpatients.py
+++ b/model/inpatients.py
@@ -179,8 +179,8 @@ class InpatientsModel(Model):
         """
         model_results = model_run.get_model_results()
 
-        # convert any "daycase" like rows after type conversion to the correct pod
-        model_results.loc[model_results["classpat"].isin(["-2", "2", "3"]), "pod"] = (
+        # handle the type conversions: change the pod's
+        model_results.loc[model_results["classpat"] == "-2", "pod"] = (
             "ip_elective_daycase"
         )
         model_results.loc[model_results["classpat"] == "-1", "pod"] = "op_procedure"

--- a/tests/test_inpatients.py
+++ b/tests/test_inpatients.py
@@ -311,7 +311,7 @@ def test_aggregate(mock_model):
             "age_group": xs,
             "sex": xs,
             "group": ["elective", "non-elective", "maternity"] * 4,
-            "classpat": ["1", "2", "3", "4", "5", "-1"] * 2,
+            "classpat": ["1", "-2", "3", "4", "5", "-1"] * 2,
             "tretspef": xs,
             "tretspef_raw": list(range(12)),
             "rn": [1] * 12,
@@ -341,7 +341,7 @@ def test_aggregate(mock_model):
         "pod": [
             "ip_elective_admission",
             "ip_elective_daycase",
-            "ip_elective_daycase",
+            "ip_maternity_admission",
             "ip_elective_admission",
             "ip_non-elective_admission",
             "op_procedure",
@@ -350,7 +350,7 @@ def test_aggregate(mock_model):
         + [
             "ip_elective_admission",
             "ip_elective_daycase",
-            "ip_elective_daycase",
+            "ip_maternity_admission",
             "ip_elective_admission",
             "ip_non-elective_admission",
         ]


### PR DESCRIPTION
changes the way we handle regular attenders in the model by separating them into their own POD.

This can be controlled by a new item in the params, "separate_regular_attenders". if missing, or true, then it will create separates POD's for regular day/night attenders. if false, then these will be mapped to `ip_elective_daycase` and `ip_elective_admission` respectively.

As this defaults to true, we don't need to add it to the inputs app. We may decide later on to add as an advanced/hidden option if it turns out people request this to be turned off.
