### PR TITLE
ensures activity that is loaded is sorted

### DIFF
--- a/model/health_status_adjustment.py
+++ b/model/health_status_adjustment.py
@@ -41,9 +41,9 @@ class HealthStatusAdjustment:
 
     def _load_activity_ages(self):
         self._activity_ages = (
-            self._data_loader.get_hsa_activity_table().set_index(
-                ["hsagrp", "sex", "age"]
-            )
+            self._data_loader.get_hsa_activity_table()
+            .set_index(["hsagrp", "sex", "age"])
+            .sort_index()
         )["activity"]
 
     @staticmethod


### PR DESCRIPTION
with the interpolated GAMs there is an implicit assumption that the data is sorted by age when we predict values.

however, this isn't always the case, the national data is randomly sorted, and the provider data is sorted but that might just be a happy little accident.

this ensures that the data is sorted so the predicitions are valid.

fixes #279
