### PR TITLE
fix issue with schema deploy

### DIFF
--- a/.github/workflows/build_schema.yaml
+++ b/.github/workflows/build_schema.yaml
@@ -27,17 +27,18 @@ jobs:
 
       - name: Copy schema to app version path
         run: |
-          mkdir schemas/${{ inputs.schema-tag }}
+          mkdir -p schemas/${{ inputs.schema-tag }}
           cp params-schema.json schemas/${{ inputs.schema-tag }}/
 
       - name: Commit the schema
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          cd schemas
-          git add .
+          pushd schemas
+          git add ${{ inputs.schema-tag }}/params-schema.json
           git commit -m "adding schema for ${{ inputs.schema-tag }}"
           git push origin schemas
+          popd
       
       - name: Upload to GitHub Pages
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
- was failing to create the directory if it already exists, as is the case with the dev folder
- use pushd/popd to ensure we return to the original directory after commiting the changes
- switches from git add . to the specific file that we have changed
