### PR TITLE
change way we delete pr images

### DIFF
--- a/.github/workflows/build_container.yaml
+++ b/.github/workflows/build_container.yaml
@@ -167,30 +167,3 @@ jobs:
         run: |
           docker tag ${{ secrets.REGISTRY_LOGIN_SERVER }}/nhp_model:${{ inputs.docker-tag }} ${{ secrets.REGISTRY_LOGIN_SERVER }}/nhp_model:latest
           docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/nhp_model:latest
-
-  remove-pr-image:
-    runs-on: ubuntu-latest
-    needs: ["deploy-ghcr", "deploy-acr"]
-    steps:
-      # you must create a classic PAT with `delete:packages` scope and add it as a secret named `PAT_DELETE_PACKAGES` 
-      - name: Authenticate with PAT
-        run: echo "${{ secrets.PAT_DELETE_PACKAGES }}" | gh auth login --with-token
-
-      - name: "Remove pr image"
-        env:
-          TAG_TO_DELETE: "pr-${{ github.event.pull_request.number }}"
-        run: |
-          VERSION_ID=$(gh api /orgs/the-strategy-unit/packages/container/nhp_model/versions \
-            -H "Accept: application/vnd.github+json" \
-            --paginate | \
-            jq -r '.[] | select(.metadata.container.tags[] == "$TAG_TO_DELETE") | .id')
-
-          if [ -n "$VERSION_ID" ]; then
-            echo "Deleting version ID: $VERSION_ID"
-            gh api \
-              -X DELETE \
-              /orgs/the-strategy-unit/packages/container/nhp_model/versions/${VERSION_ID} \
-              -H "Accept: application/vnd.github+json"
-          else
-            echo "Tag '$TAG_TO_DELETE' not found — skipping delete"
-          fi

--- a/.github/workflows/removed_closed_prs.yaml
+++ b/.github/workflows/removed_closed_prs.yaml
@@ -7,7 +7,6 @@ on:
 jobs:
   removed-untagged-images:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged == false
     steps:
       # you must create a classic PAT with `delete:packages` scope and add it as a secret named `PAT_DELETE_PACKAGES` 
       - name: Authenticate with PAT


### PR DESCRIPTION
wasn't triggering correctly before. because we rely on github actions for caching we don't need to worry about keeping the image until the dev/vX.Y image is tagged, so we can independently delete the pr image when the pr is closed.
