### PR TITLE
fixes docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ FROM ghcr.io/astral-sh/uv:python3.11-alpine
 
 # Create user
 RUN addgroup -g 1000 nhp && adduser -u 1000 -G nhp -s /bin/sh -h /app -D nhp
+# temporary fix, should change the api to run ./docker_run.py rather than /opt/docker_run.py
+RUN rmdir /opt && ln -s /app /opt
 WORKDIR /app
 USER nhp
 

--- a/docker_run.py
+++ b/docker_run.py
@@ -1,4 +1,4 @@
-#!/opt/conda/bin/python
+#!/app/.venv/bin/python
 """Run the model inside of the docker container"""
 
 import argparse


### PR DESCRIPTION
fixes issue where the api expects the code to be in /opt. it's now in /app, so a temporary fix is to symlink /opt->/app

changes the location of the python executable as we have switched away from conda
