### PR TITLE
fixes build issues when pushing to ghcr

### DIFF
--- a/.github/workflows/build_container.yaml
+++ b/.github/workflows/build_container.yaml
@@ -58,6 +58,9 @@ jobs:
           push: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          platforms: linux/amd64
+          provenance: false
+          sbom: false
           build-args: |
             app_version=${{ inputs.app-version }}
             data_version=${{ inputs.data-version }}
@@ -104,8 +107,6 @@ jobs:
           registry: ghcr.io
           username: ${{github.actor}}
           password: ${{secrets.GITHUB_TOKEN}}
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
 
       - name: Set tags
         id: set-tags
@@ -117,6 +118,9 @@ jobs:
           echo "tags=$TAGS" >> $GITHUB_OUTPUT
           echo "Deploying as: $TAGS"
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: "Build image"
         uses: docker/build-push-action@v6
         with:
@@ -124,6 +128,9 @@ jobs:
           tags: ${{ steps.set-tags.outputs.tags }}
           push: true
           cache-from: type=gha
+          platforms: linux/amd64
+          provenance: false
+          sbom: false
           build-args: |
             app_version=${{ inputs.app-version }}
             data_version=${{ inputs.data-version }}
@@ -147,9 +154,6 @@ jobs:
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
       - name: Set tags
         id: set-tags
         run: |
@@ -160,6 +164,9 @@ jobs:
           echo "tags=$TAGS" >> $GITHUB_OUTPUT
           echo "Deploying as: $TAGS"
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: "Build image"
         uses: docker/build-push-action@v6
         with:
@@ -167,6 +174,7 @@ jobs:
           tags: ${{ steps.set-tags.outputs.tags }}
           push: true
           cache-from: type=gha
+          platforms: linux/amd64
           build-args: |
             app_version=${{ inputs.app-version }}
             data_version=${{ inputs.data-version }}


### PR DESCRIPTION
the manifest was not being created after switching to the docker build-push-action in v3.6.0, but only for ghcr. this was preventing the containers from being pulled

setting these options fixes the builds