### PR TITLE
refactor data loading

### DIFF
--- a/notebooks/national_run.py
+++ b/notebooks/national_run.py
@@ -47,9 +47,6 @@ dbutils.widgets.text("sample_rate", "0.01", "Sample Rate")
 
 # COMMAND ----------
 
-import sys
-
-sys.path.append(spark.conf.get("bundle.sourcePath", "."))
 
 import gzip
 import json
@@ -61,10 +58,10 @@ import pyspark.sql.functions as F
 from azure.storage.blob import ContainerClient
 
 from nhp import model as mdl
-from nhp.model.__main__ import _run_model
 from nhp.model.data.databricks import DatabricksNational
 from nhp.model.health_status_adjustment import HealthStatusAdjustmentInterpolated
 from nhp.model.results import combine_results, generate_results_json, save_results_files
+from nhp.model.run import _run_model
 
 os.environ["BATCH_SIZE"] = "8"
 

--- a/src/nhp/model/aae.py
+++ b/src/nhp/model/aae.py
@@ -53,8 +53,8 @@ class AaEModel(Model):
             save_full_model_results,
         )
 
-    def _get_data(self) -> pd.DataFrame:
-        return self._data_loader.get_aae()
+    def _get_data(self, data_loader: Data) -> pd.DataFrame:
+        return data_loader.get_aae()
 
     def _add_pod_to_data(self) -> None:
         """Adds the POD column to data"""
@@ -70,7 +70,7 @@ class AaEModel(Model):
         """
         return np.array([data["arrivals"]]).astype(float)
 
-    def _load_strategies(self) -> None:
+    def _load_strategies(self, data_loader: Data) -> None:
         """Loads the activity mitigation strategies"""
         data = self.data.set_index("rn")
         self.strategies = {

--- a/src/nhp/model/health_status_adjustment.py
+++ b/src/nhp/model/health_status_adjustment.py
@@ -19,14 +19,12 @@ class HealthStatusAdjustment:
 
     # load the static reference data files
 
-    def __init__(self, data: Data, base_year: str):
+    def __init__(self, data_loader: Data, base_year: str):
         self._all_ages = np.arange(0, 101)
-        self._data_loader = data
 
         self._load_life_expectancy_series(base_year)
-        self._load_activity_ages()
+        self._load_activity_ages(data_loader)
         self._cache = {}
-        self._data_loader = None
 
     def _load_life_expectancy_series(self, base_year: str):
         # the age range that health status adjustment runs for
@@ -38,9 +36,9 @@ class HealthStatusAdjustment:
         # calculate the life expectancy (change) between the model year and base year
         self._life_expectancy = lexc.apply(lambda x: x - lexc[str(base_year)])
 
-    def _load_activity_ages(self):
+    def _load_activity_ages(self, data_loader: Data):
         self._activity_ages = (
-            self._data_loader.get_hsa_activity_table()
+            data_loader.get_hsa_activity_table()
             .set_index(["hsagrp", "sex", "age"])
             .sort_index()
         )["activity"]
@@ -91,7 +89,9 @@ class HealthStatusAdjustment:
         variant_lookup = reference.variant_lookup()
         return [
             values[variant_lookup[v]][i]
-            for i, v in enumerate(variants + variants[0:1] * (end_year - start_year - 1))
+            for i, v in enumerate(
+                variants + variants[0:1] * (end_year - start_year - 1)
+            )
         ]
 
     @staticmethod

--- a/src/nhp/model/inpatients.py
+++ b/src/nhp/model/inpatients.py
@@ -74,10 +74,10 @@ class InpatientsModel(Model):
         super()._add_ndggrp_to_data()
         self.data.loc[self.data["admimeth"].isin(["82", "83"]), "ndggrp"] = "maternity"
 
-    def _get_data(self) -> pd.DataFrame:
-        return self._data_loader.get_ip()
+    def _get_data(self, data_loader: Data) -> pd.DataFrame:
+        return data_loader.get_ip()
 
-    def _load_strategies(self) -> None:
+    def _load_strategies(self, data_loader: Data) -> None:
         """Load a set of strategies"""
 
         def filter_valid(strategy_type, strats):
@@ -114,8 +114,7 @@ class InpatientsModel(Model):
             )
 
         self.strategies = {
-            k: filter_valid(k, v)
-            for k, v in self._data_loader.get_ip_strategies().items()
+            k: filter_valid(k, v) for k, v in data_loader.get_ip_strategies().items()
         }
 
         # set admissions without a strategy selected to general_los_reduction_X

--- a/src/nhp/model/outpatients.py
+++ b/src/nhp/model/outpatients.py
@@ -54,8 +54,8 @@ class OutpatientsModel(Model):
             save_full_model_results,
         )
 
-    def _get_data(self) -> pd.DataFrame:
-        return self._data_loader.get_op()
+    def _get_data(self, data_loader: Data) -> pd.DataFrame:
+        return data_loader.get_op()
 
     def _add_pod_to_data(self) -> None:
         """Adds the POD column to data"""
@@ -71,7 +71,7 @@ class OutpatientsModel(Model):
             .transpose()
         )
 
-    def _load_strategies(self):
+    def _load_strategies(self, data_loader: Data) -> None:
         data = self.data.set_index("rn")
 
         self.strategies = {

--- a/tests/nhp/model/test_aae.py
+++ b/tests/nhp/model/test_aae.py
@@ -91,14 +91,15 @@ def test_init_calls_super_init(mocker):
 def test_get_data(mock_model):
     # arrange
     mdl = mock_model
-    mdl._data_loader.get_aae.return_value = "aae data"
+    data_loader = Mock()
+    data_loader.get_aae.return_value = "aae data"
 
     # act
-    actual = mdl._get_data()
+    actual = mdl._get_data(data_loader)
 
     # assert
     assert actual == "aae data"
-    mdl._data_loader.get_aae.assert_called_once_with()
+    data_loader.get_aae.assert_called_once_with()
 
 
 def test_add_pod_to_data(mock_model):
@@ -137,7 +138,7 @@ def test_load_strategies(mock_model):
     )
     mdl.data["is_discharged_no_treatment"] = [False] * 16 + [True] * 4
     # act
-    mdl._load_strategies()
+    mdl._load_strategies(None)
     # assert
     assert mdl.strategies["activity_avoidance"]["strategy"].to_list() == [
         "frequent_attenders_a_a",

--- a/tests/nhp/model/test_health_status_adjustment.py
+++ b/tests/nhp/model/test_health_status_adjustment.py
@@ -24,7 +24,6 @@ def mock_hsa():
         hsa = HealthStatusAdjustment(None, None)
 
     hsa._all_ages = np.arange(0, 101)
-    hsa._data_loader = Mock()
     hsa._cache = dict()
 
     return hsa
@@ -45,11 +44,10 @@ def test_hsa_init(mocker):
 
     # assert
     assert hsa._all_ages.tolist() == list(range(0, 101))
-    assert hsa._data_loader is None
     assert hsa._cache == {}
 
     lle_mock.assert_called_once_with(2020)
-    laa_mock.assert_called_once_with()
+    laa_mock.assert_called_once_with("nhp_data")
 
 
 @pytest.mark.parametrize(
@@ -122,7 +120,8 @@ def test_hsa_load_life_expectancy_series_filters_ages(mocker, mock_hsa):
 
 def test_load_activity_ages(mock_hsa):
     # arrange
-    mock_hsa._data_loader.get_hsa_activity_table.return_value = pd.DataFrame(
+    data_loader = Mock()
+    data_loader.get_hsa_activity_table.return_value = pd.DataFrame(
         {
             "hsagrp": ["a"] * 4 + ["b"] * 4,
             "sex": [1, 2] * 4,
@@ -132,7 +131,7 @@ def test_load_activity_ages(mock_hsa):
     )
 
     # act
-    mock_hsa._load_activity_ages()
+    mock_hsa._load_activity_ages(data_loader)
 
     # assert
     assert mock_hsa._activity_ages.to_dict() == {
@@ -370,7 +369,9 @@ def test_hsa_gam_predict_activity(mock_hsa_gam):
 @pytest.fixture
 def mock_hsa_interpolated():
     """create a mock Model instance"""
-    with patch.object(HealthStatusAdjustmentInterpolated, "__init__", lambda *args: None):
+    with patch.object(
+        HealthStatusAdjustmentInterpolated, "__init__", lambda *args: None
+    ):
         hsa = HealthStatusAdjustmentInterpolated(None, None)
 
     hsa._activity_ages = pd.Series(

--- a/tests/nhp/model/test_inpatients.py
+++ b/tests/nhp/model/test_inpatients.py
@@ -138,7 +138,9 @@ def test_add_pod_to_data(mock_model):
         (False, ["ip_elective_daycase", "ip_elective_admission"]),
     ],
 )
-def test_add_pod_to_data_separate_regular_day_attenders_param(mock_model, test, expected):
+def test_add_pod_to_data_separate_regular_day_attenders_param(
+    mock_model, test, expected
+):
     # arrange
     mock_model.data = pd.DataFrame(
         {
@@ -177,14 +179,15 @@ def test_add_pod_to_data_no_regular_attenders(mock_model):
 def test_get_data(mock_model):
     # arrange
     mdl = mock_model
-    mdl._data_loader.get_ip.return_value = "ip data"
+    data_loader = Mock()
+    data_loader.get_ip.return_value = "ip data"
 
     # act
-    actual = mdl._get_data()
+    actual = mdl._get_data(data_loader)
 
     # assert
     assert actual == "ip data"
-    mdl._data_loader.get_ip.assert_called_once_with()
+    data_loader.get_ip.assert_called_once_with()
 
 
 @pytest.mark.parametrize(
@@ -206,7 +209,9 @@ def test_load_strategies(mock_model, gen_los_type, expected):
         "activity_avoidance": {"ip": {"a": 1, "b": 2}},
         "efficiencies": {"ip": {"b": 3, "c": 4, gen_los_type: 5}},
     }
-    mdl._data_loader.get_ip_strategies.return_value = {
+
+    data_loader = Mock()
+    data_loader.get_ip_strategies.return_value = {
         "activity_avoidance": pd.DataFrame(
             {"rn": [1, 2, 3], "admission_avoidance_strategy": ["a", "b", "c"]}
         ),
@@ -222,7 +227,7 @@ def test_load_strategies(mock_model, gen_los_type, expected):
     }
 
     # act
-    mdl._load_strategies()
+    mdl._load_strategies(data_loader)
 
     # assert
     assert {k: v.to_dict() for k, v in mdl.strategies.items()} == expected

--- a/tests/nhp/model/test_outpatients.py
+++ b/tests/nhp/model/test_outpatients.py
@@ -89,14 +89,15 @@ def test_init_calls_super_init(mocker):
 def test_get_data(mock_model):
     # arrange
     mdl = mock_model
-    mdl._data_loader.get_op.return_value = "op data"
+    data_loader = Mock()
+    data_loader.get_op.return_value = "op data"
 
     # act
-    actual = mdl._get_data()
+    actual = mdl._get_data(data_loader)
 
     # assert
     assert actual == "op data"
-    mdl._data_loader.get_op.assert_called_once_with()
+    data_loader.get_op.assert_called_once_with()
 
 
 def test_add_pod_to_data(mock_model):
@@ -143,7 +144,7 @@ def test_load_strategies(mock_model):
     mdl.data["type"] = ["a", "b", "c", "d", "e"] * 4
     mdl.data["is_gp_ref"] = [False] * 10 + [True] * 10
     # act
-    mdl._load_strategies()
+    mdl._load_strategies(None)
     # assert
     assert mdl.strategies["activity_avoidance"]["strategy"].to_list() == [
         f"{i}_{j}"
@@ -180,7 +181,10 @@ def test_convert_to_tele(mock_model):
     }
     mr_mock.model.strategies = {
         "efficiencies": pd.Series(
-            {k: "convert_to_tele_a" if k % 2 else "convert_to_tele_b" for k in data["rn"]}
+            {
+                k: "convert_to_tele_a" if k % 2 else "convert_to_tele_b"
+                for k in data["rn"]
+            }
         )
     }
 
@@ -289,7 +293,9 @@ def test_process_results(mock_model):
         }
     )
     expected = {
-        "pod": [k for k in ["op_first", "op_follow-up", "op_procedure"] for _ in [0, 1]],
+        "pod": [
+            k for k in ["op_first", "op_follow-up", "op_procedure"] for _ in [0, 1]
+        ],
         "sitetret": ["trust"] * 6,
         "measure": ["attendances", "tele_attendances"] * 3,
         "sex": [1] * 6,


### PR DESCRIPTION
previously the `Data` class was added to the Model class as self._data_loader, but to work properly in spark we had to set the value to None before the end of the constructor.

this refactors the code to pass the data_loader object to the methods that need it, so we do not have to assign/unassign the value

locally ensured that the code runs in the docker containers, and checked on databricks that national notebook still runs