### PR TITLE
improve progress reporting

### DIFF
--- a/src/nhp/model/run.py
+++ b/src/nhp/model/run.py
@@ -102,6 +102,8 @@ def _run_model(
             )
         )
     logging.info(" * finished")
+    # ensure that the callback reports all model runs are complete
+    progress_callback(params["model_runs"])
 
     return results
 

--- a/tests/nhp/model/test_run.py
+++ b/tests/nhp/model/test_run.py
@@ -59,7 +59,7 @@ def test_run_model(mocker):
     # assert
     pool_ctm.imap.assert_called_once_with(model_m().go, [0, 1, 2], chunksize=1)
     assert actual == [model_m().go()] * 3
-    pc_m.assert_not_called()
+    pc_m.assert_called_once_with(2)
 
 
 def test_run_all(mocker):


### PR DESCRIPTION
there is a tqdm callback which can be used to report progress by updating the metadata of the params file in queue.

but, currently this callback doesn't always report that all of the runs are completed.

this ensures that when we have finished running we update the metadata with the amount of model runs, signalling that the stage has been complete
