### PR TITLE
fix issues caused by #443

### DIFF
--- a/src/nhp/docker/__main__.py
+++ b/src/nhp/docker/__main__.py
@@ -63,7 +63,7 @@ def main():
     logging.info("app_version:  %s", runner.params["app_version"])
 
     saved_files, results_file = run_all(
-        runner.params, "data", runner.progress_callback, args.save_full_model_results
+        runner.params, "data", runner.progress_callback(), args.save_full_model_results
     )
 
     runner.finish(results_file, saved_files, args.save_full_model_results)

--- a/src/nhp/docker/run.py
+++ b/src/nhp/docker/run.py
@@ -14,6 +14,7 @@ from azure.storage.filedatalake import DataLakeServiceClient
 
 from nhp.docker import config
 from nhp.model.helpers import load_params
+from nhp.model.run import noop_progress_callback
 
 
 class RunWithLocalStorage:
@@ -44,7 +45,7 @@ class RunWithLocalStorage:
 
         for local storage do nothing
         """
-        return lambda _: lambda _: None
+        return noop_progress_callback
 
 
 class RunWithAzureStorage:
@@ -237,8 +238,8 @@ class RunWithAzureStorage:
 
         blob.set_blob_metadata({k: str(v) for k, v in current_progress.items()})
 
-        def callback(model_type):
-            def update(n_completed):
+        def callback(model_type: Any) -> Callable[[Any], None]:
+            def update(n_completed: Any) -> None:
                 current_progress[model_type] = n_completed
                 blob.set_blob_metadata({k: str(v) for k, v in current_progress.items()})
 

--- a/src/nhp/model/__main__.py
+++ b/src/nhp/model/__main__.py
@@ -66,7 +66,7 @@ def main() -> None:
             run_all(
                 params,
                 args.data_path,
-                lambda: lambda _: None,
+                lambda _: lambda _: None,
                 args.save_full_model_results,
             )
             return

--- a/src/nhp/model/model_iteration.py
+++ b/src/nhp/model/model_iteration.py
@@ -173,7 +173,7 @@ class ModelIteration:
             for v in [[], ["sex", "age_group"], ["age"], *aggregations]
         }
 
-        if self.avoided_activity is not None:
+        if not self.avoided_activity.empty:
             avoided_activity_agg = self.model.process_results(self.avoided_activity)
             aggs["avoided_activity"] = self.model.get_agg(avoided_activity_agg, "sex", "age_group")
 

--- a/src/nhp/model/outpatients.py
+++ b/src/nhp/model/outpatients.py
@@ -128,7 +128,7 @@ class OutpatientsModel(Model):
         params = model_iteration.run_params["efficiencies"]["op"]
         strategies = model_iteration.model.strategies["efficiencies"]
         # make sure to take the complement of the parameter
-        factor = 1 - data["rn"].map(strategies.map(params)).fillna(1)
+        factor = 1 - data["rn"].map(strategies["strategy"].map(params)).fillna(1)
         # create a value for converting attendances into tele attendances for each row
         # the value will be a random binomial value, i.e. we will convert between 0 and attendances
         # into tele attendances

--- a/src/nhp/model/run.py
+++ b/src/nhp/model/run.py
@@ -104,8 +104,16 @@ def _run_model(
     return results
 
 
+def noop_progress_callback(_: Any) -> Callable[[Any], None]:
+    """A no-op callback."""
+    return lambda _: None
+
+
 def run_all(
-    params: dict, data_path: str, progress_callback, save_full_model_results: bool
+    params: dict,
+    data_path: str,
+    progress_callback: Callable[[Any], Callable[[Any], None]] = noop_progress_callback,
+    save_full_model_results: bool = False,
 ) -> Tuple[list, str]:
     """Run the model.
 
@@ -115,6 +123,11 @@ def run_all(
     :type params: dict
     :param data_path: where the data is stored
     :type data_path: str
+    :param progress_callback: a callback function for updating progress.
+        Defaults to noop_progress_callback.
+    :type progress_callback: Callable[[str], Callable[[Any], Any]]
+    :param save_full_model_results: whether to save full model results, defaults to False
+    :type save_full_model_results: bool
     :return: the filename of the saved results
     :rtype: str
     """
@@ -128,8 +141,6 @@ def run_all(
         nhp_data(params["start_year"], params["dataset"]), params["start_year"]
     )
 
-    pcallback = progress_callback()
-
     results, step_counts = combine_results(
         [
             _run_model(
@@ -138,7 +149,7 @@ def run_all(
                 nhp_data,
                 hsa,
                 run_params,
-                pcallback(m.__name__[:-5]),
+                progress_callback(m.__name__[:-5]),
                 save_full_model_results,
             )
             for m in model_types

--- a/tests/nhp/docker/test___main__.py
+++ b/tests/nhp/docker/test___main__.py
@@ -79,7 +79,7 @@ def test_main_local(mocker):
     rwas.assert_not_called()
 
     s = rwls()
-    ru_m.assert_called_once_with(params, "data", s.progress_callback, False)
+    ru_m.assert_called_once_with(params, "data", s.progress_callback(), False)
     s.finish.assert_called_once_with("results.json", "list_of_results", False)
 
 
@@ -115,7 +115,7 @@ def test_main_azure(mocker):
     rwas.assert_called_once_with("params.json", "dev")
 
     s = rwas()
-    ru_m.assert_called_once_with(params, "data", s.progress_callback, False)
+    ru_m.assert_called_once_with(params, "data", s.progress_callback(), False)
     s.finish.assert_called_once_with("results.json", "list_of_results", False)
 
 

--- a/tests/nhp/model/test__main__.py
+++ b/tests/nhp/model/test__main__.py
@@ -79,7 +79,7 @@ def test_main_all_runs(mocker):
     run_all_mock.assert_called_once()
     assert run_all_mock.call_args[0][0] == "params"
     assert run_all_mock.call_args[0][1] == "data"
-    assert run_all_mock.call_args[0][2]()(0) is None
+    assert run_all_mock.call_args[0][2]("a")(0) is None
 
     run_single_mock.assert_not_called()
     ldp_mock.assert_called_once_with("queue/params.json")

--- a/tests/nhp/model/test_model_iteration.py
+++ b/tests/nhp/model/test_model_iteration.py
@@ -222,7 +222,7 @@ def test_get_aggregate_results(mock_model_iteration):
     mr_mock.model.aggregate.return_value = "aggregated_results", [["a"]]
     mr_mock.get_step_counts = Mock(return_value="step_counts")
     mr_mock.model.get_agg.return_value = "agg"
-    mr_mock.avoided_activity = "avoided_activity"
+    mr_mock.avoided_activity = pd.DataFrame({"x": ["avoided_activity"]})
     mr_mock.model.process_results = Mock(return_value="avoided_activity_agg")
 
     # act
@@ -241,7 +241,7 @@ def test_get_aggregate_results(mock_model_iteration):
     )
     mr_mock.model.aggregate.assert_called_once_with(mr_mock)
     mr_mock.get_step_counts.assert_called_once_with()
-    mr_mock.model.process_results.assert_called_once_with("avoided_activity")
+    mr_mock.model.process_results.assert_called_once_with(mr_mock.avoided_activity)
 
     assert mr_mock.model.get_agg.call_args_list == [
         call("aggregated_results"),
@@ -252,7 +252,7 @@ def test_get_aggregate_results(mock_model_iteration):
     ]
 
 
-def test_get_aggregate_results_avoided_activity_none(mock_model_iteration):
+def test_get_aggregate_results_avoided_activity_empty_dataframe(mock_model_iteration):
     """Test the get_aggregate_results method when avoided activity is None."""
     # arrange
     mr_mock = mock_model_iteration
@@ -260,7 +260,7 @@ def test_get_aggregate_results_avoided_activity_none(mock_model_iteration):
     mr_mock.model.aggregate.return_value = "aggregated_results", [["a"]]
     mr_mock.get_step_counts = Mock(return_value="step_counts")
     mr_mock.model.get_agg.return_value = "agg"
-    mr_mock.avoided_activity = None
+    mr_mock.avoided_activity = pd.DataFrame
     mr_mock.model.process_results = Mock(return_value="avoided_activity_agg")
 
     # act

--- a/tests/nhp/model/test_outpatients.py
+++ b/tests/nhp/model/test_outpatients.py
@@ -171,9 +171,12 @@ def test_convert_to_tele(mock_model):
         "efficiencies": {"op": {"convert_to_tele_a": 0.25, "convert_to_tele_b": 0.5}}
     }
     mr_mock.model.strategies = {
-        "efficiencies": pd.Series(
-            {k: "convert_to_tele_a" if k % 2 else "convert_to_tele_b" for k in data["rn"]}
-        )
+        "efficiencies": pd.DataFrame(
+            [
+                {"rn": k, "strategy": "convert_to_tele_a" if k % 2 else "convert_to_tele_b"}
+                for k in data["rn"]
+            ]
+        ).set_index("rn")
     }
 
     # act

--- a/tests/nhp/model/test_run.py
+++ b/tests/nhp/model/test_run.py
@@ -8,7 +8,14 @@ import pytest
 from nhp.model.aae import AaEModel
 from nhp.model.inpatients import InpatientsModel
 from nhp.model.outpatients import OutpatientsModel
-from nhp.model.run import _run_model, run_all, run_single_model_run, timeit, tqdm
+from nhp.model.run import (
+    _run_model,
+    noop_progress_callback,
+    run_all,
+    run_single_model_run,
+    timeit,
+    tqdm,
+)
 
 
 def test_tqdm():
@@ -60,6 +67,11 @@ def test_run_model(mocker):
     pc_m.assert_called_once_with(2)
 
 
+def test_noop_progress_callback():
+    # arrange, act & assert
+    assert not noop_progress_callback("a")("b")
+
+
 def test_run_all(mocker):
     # arrange
     grp_m = mocker.patch(
@@ -101,8 +113,7 @@ def test_run_all(mocker):
     nd_c = nd_m.create()
     nd_c.assert_called_once_with(2020, "synthetic")
 
-    pc_m.assert_called_once_with()
-    assert pc_m().call_args_list == [
+    assert pc_m.call_args_list == [
         call("Inpatients"),
         call("Outpatients"),
         call("AaE"),
@@ -118,7 +129,7 @@ def test_run_all(mocker):
             nd_c,
             "hsa",
             {"variant": "variants"},
-            "progress callback",
+            pc_m(),
             False,
         )
         for m in [InpatientsModel, OutpatientsModel, AaEModel]


### PR DESCRIPTION
must have forgot to *actually* run more than just model run 1 for inpatients, but introduced a couple of bugs in #443. This rectifies these issues

- **avoided_activity is no longer None, it's now an empty dataframe**
- **fixes outpatients strategies**
- **adds typing for the progress callbacks and makes a default noop function**
