### PR TITLE
fix issue with config tests

### DIFF
--- a/src/nhp/docker/config.py
+++ b/src/nhp/docker/config.py
@@ -1,17 +1,15 @@
 """config values for docker container."""
 
-import os
-
 import dotenv
 
-dotenv.load_dotenv()
+__config_values = dotenv.dotenv_values()
 
-APP_VERSION = os.environ.get("APP_VERSION", "dev")
-DATA_VERSION = os.environ.get("DATA_VERSION", "dev")
+APP_VERSION = __config_values.get("APP_VERSION", "dev")
+DATA_VERSION = __config_values.get("DATA_VERSION", "dev")
 
-STORAGE_ACCOUNT = os.environ.get("STORAGE_ACCOUNT", None)
+STORAGE_ACCOUNT = __config_values.get("STORAGE_ACCOUNT", None)
 
 __DEFAULT_CONTAINER_TIMEOUT_SECONDS = 60 * 60  # 1 hour
 CONTAINER_TIMEOUT_SECONDS = int(
-    os.environ.get("CONTAINER_TIMEOUT_SECONDS", __DEFAULT_CONTAINER_TIMEOUT_SECONDS)
+    __config_values.get("CONTAINER_TIMEOUT_SECONDS", __DEFAULT_CONTAINER_TIMEOUT_SECONDS)  # type: ignore
 )

--- a/src/nhp/docker/config.py
+++ b/src/nhp/docker/config.py
@@ -4,10 +4,11 @@ import dotenv
 
 __config_values = dotenv.dotenv_values()
 
-APP_VERSION = __config_values.get("APP_VERSION", "dev")
-DATA_VERSION = __config_values.get("DATA_VERSION", "dev")
 
-STORAGE_ACCOUNT = __config_values.get("STORAGE_ACCOUNT", None)
+APP_VERSION: str = __config_values.get("APP_VERSION", "dev")  # type: ignore
+DATA_VERSION: str = __config_values.get("DATA_VERSION", "dev")  # type: ignore
+
+STORAGE_ACCOUNT: str | None = __config_values.get("STORAGE_ACCOUNT", None)
 
 __DEFAULT_CONTAINER_TIMEOUT_SECONDS = 60 * 60  # 1 hour
 CONTAINER_TIMEOUT_SECONDS = int(

--- a/tests/unit/nhp/docker/test_config.py
+++ b/tests/unit/nhp/docker/test_config.py
@@ -1,5 +1,4 @@
 import importlib
-import os
 from unittest.mock import patch
 
 import nhp.docker.config as c
@@ -7,30 +6,29 @@ import nhp.docker.config as c
 
 def test_config_sets_values_from_envvars(mocker):
     # arrange
-    mocker.patch("dotenv.load_dotenv")
-
-    # act
-    with patch.dict(
-        os.environ,
-        {
+    mocker.patch(
+        "dotenv.dotenv_values",
+        return_value={
             "APP_VERSION": "app version",
             "DATA_VERSION": "data version",
             "STORAGE_ACCOUNT": "storage account",
             "CONTAINER_TIMEOUT_SECONDS": "123",
         },
-    ):
-        importlib.reload(c)
+    )
 
-        # assert
-        assert c.APP_VERSION == "app version"
-        assert c.DATA_VERSION == "data version"
-        assert c.STORAGE_ACCOUNT == "storage account"
-        assert c.CONTAINER_TIMEOUT_SECONDS == 123
+    # act
+    importlib.reload(c)
+
+    # assert
+    assert c.APP_VERSION == "app version"
+    assert c.DATA_VERSION == "data version"
+    assert c.STORAGE_ACCOUNT == "storage account"
+    assert c.CONTAINER_TIMEOUT_SECONDS == 123
 
 
 def test_config_uses_default_values(mocker):
     # arrange
-    mocker.patch("dotenv.load_dotenv")
+    mocker.patch("dotenv.dotenv_values", return_value={})
 
     # act
     importlib.reload(c)
@@ -44,7 +42,7 @@ def test_config_uses_default_values(mocker):
 
 def test_config_calls_dotenv_load(mocker):
     # arrange
-    m = mocker.patch("dotenv.load_dotenv")
+    m = mocker.patch("dotenv.dotenv_values", return_value={})
 
     # act
     importlib.reload(c)

--- a/tests/unit/nhp/docker/test_run.py
+++ b/tests/unit/nhp/docker/test_run.py
@@ -164,12 +164,12 @@ def test_RunWithAzureStorage_get_data(mock_run_with_azure_storage, mocker):
     dac_m = mocker.patch("nhp.docker.run.DefaultAzureCredential", return_value="cred")
 
     config.STORAGE_ACCOUNT = "sa"
+
     # act
     with patch("builtins.open", mock_open()) as mock_file:
         s._get_data(2020, "synthetic")
 
     # assert
-
     dlsc_m.assert_called_once_with(account_url="https://sa.dfs.core.windows.net", credential="cred")
     dac_m.assert_called_once_with()
 


### PR DESCRIPTION
the tests were not properly mocking the dotenv values, which caused the test to behave unexpectedly if users had a .env file with actual values in.

refactored the code to use dotenv.dotenv_values instead: this gives us a dictionary of the values in the .env file, rather than appending to the environment variables.