### PR TITLE
improve exception handling in containers

### DIFF
--- a/tests/unit/nhp/model/test_run.py
+++ b/tests/unit/nhp/model/test_run.py
@@ -62,7 +62,7 @@ def test_run_model(mocker):
     actual = _run_model(model_m, params, "data", "hsa", "run_params", pc_m, False)  # type: ignore
 
     # assert
-    pool_ctm.imap.assert_called_once_with(model_m().go, [0, 1, 2], chunksize=1)
+    pool_ctm.imap.assert_called_once_with(model_m().go, [1, 2], chunksize=1)
     assert actual == [model_m().go()] * 3
     pc_m.assert_called_once_with(2)
 


### PR DESCRIPTION
There has been a longstanding issue where if there is an error in the code, the docker containers do not gracefully exit. They instead just hang.

This is a problem because we will be billed until we manually shut down the container. To date, we have handled this by adding in a timeout (with a default of 1hour) to kill the container.

This PR wraps the `main()` call in a try-except block. If we encounter an error it is logged, and then we return a non-zero exit code from the container.

Also refactored the `run()` method to separate out the baseline and model iterations - this is a bit neater in terms of how we utilise the multiprocessing pool and reduces the risk of changes to how we perform parallel computation (e.g. if we switched to a method that does not guarantee returning results in order).