### PR TITLE
Allow one population projection variant in the schema with value 1

### DIFF
--- a/params-schema.json
+++ b/params-schema.json
@@ -44,32 +44,33 @@
                     "type": "object",
                     "properties": {
                         "migration_category": {
-                            "$ref": "#/$defs/value_gt0-1"
+                            "$ref": "#/$defs/value_1"
                         },
                         "var_proj_5_year_migration": {
-                            "$ref": "#/$defs/value_gt0-1"
+                            "$ref": "#/$defs/value_1"
                         },
                         "var_proj_10_year_migration": {
-                            "$ref": "#/$defs/value_gt0-1"
+                            "$ref": "#/$defs/value_1"
                         },
                         "var_proj_high_intl_migration": {
-                            "$ref": "#/$defs/value_gt0-1"
+                            "$ref": "#/$defs/value_1"
                         },
                         "var_proj_low_intl_migration": {
-                            "$ref": "#/$defs/value_gt0-1"
+                            "$ref": "#/$defs/value_1"
                         },
                         "var_proj_zero_net_migration": {
-                            "$ref": "#/$defs/value_gt0-1"
+                            "$ref": "#/$defs/value_1"
                         },
                         "custom_projection_R0A66": {
-                            "$ref": "#/$defs/value_gt0-1"
+                            "$ref": "#/$defs/value_1"
                         },
                         "custom_projection_RD8": {
-                            "$ref": "#/$defs/value_gt0-1"
+                            "$ref": "#/$defs/value_1"
                         }
                     },
                     "additionalProperties": false,
-                    "minProperties": 1
+                    "minProperties": 1,
+                    "maxProperties": 1
                 }
             },
             "required": [
@@ -1316,10 +1317,9 @@
             "minimum": 0,
             "maximum": 1
         },
-        "value_gt0-1": {
+        "value_1": {
             "type": "number",
-            "exclusiveMinimum": 0,
-            "maximum": 1
+            "const": 1
         },
         "value_1-5": {
             "type": "number",

--- a/queue/params-sample.json
+++ b/queue/params-sample.json
@@ -10,11 +10,7 @@
   "create_datetime": "20220101_000000",
   "demographic_factors": {
     "variant_probabilities": {
-      "migration_category": 0.40,
-      "var_proj_10_year_migration": 0.15,
-      "var_proj_zero_net_migration": 0.15,
-      "var_proj_high_intl_migration": 0.15,
-      "var_proj_low_intl_migration": 0.15
+      "migration_category": 1
     }
   },
   "health_status_adjustment": true,


### PR DESCRIPTION
Close #456. Towards #424.

* Replaced `value_gt0-1` definition with `value_1` (i.e. constant of 1) to ensure only a value of 1 can be set for the chosen variant.
* Set both `minProperties` and `maxProperties` to 1 to ensure exactly one variant can be set (although I think there might be a cleverer way using `oneOf`?).
* Update the `params-sample.json` so it complies with new population-projection rules.

I tested the schema against a `test-params.json` with accepted variant names (including customs); non-1 values; fabricated variant names; multiple named variants; empty `variant_probabilities`; and empty `demographic_factors`. They all passed/failed as expected. Validation code for posterity:

```r
schema <- jsonvalidate::json_schema$new("params-schema.json")
schema$validate("test-params.json", verbose = TRUE)
```