### PR TITLE
force factor to be treated as float

### DIFF
--- a/src/nhp/model/activity_resampling.py
+++ b/src/nhp/model/activity_resampling.py
@@ -81,9 +81,11 @@ class ActivityResampling:
     def _update(self, factor: pd.Series):
         step = factor.name
 
-        factor = self.data.merge(factor, how="left", left_on=factor.index.names, right_index=True)[
-            step
-        ].fillna(1)
+        factor = (
+            self.data.merge(factor, how="left", left_on=factor.index.names, right_index=True)[step]
+            .astype(float)
+            .fillna(1.0)
+        )
 
         self.factors.append(factor)
 


### PR DESCRIPTION
without this, getting the following warning when running in databricks:

```
FutureWarning: Downcasting object dtype arrays on .fillna, .ffill, .bfill is deprecated and will change in a future version
```

this should prevent this warning from appearing.
