### PR TITLE
tidy up project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -255,4 +255,4 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
-src/nhp/_version.py
+src/nhp/model/_version.py

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,0 @@
-# sample regex patterns
-ignore:
-  - "tests/test*.py"
-  - "migration/*.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,7 +116,7 @@ pythonVersion = "3.11"
 typeCheckingMode = "basic"
 
 [tool.setuptools_scm]
-version_file = "src/nhp/_version.py"
+version_file = "src/nhp/model/_version.py"
 
 [tool.ty.src]
 exclude = ["notebooks"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "nhp_model"
+name = "nhp-model"
 dynamic = ["version"]
 description = "New Hospital Programme demand model"
 

--- a/src/nhp/__init__.py
+++ b/src/nhp/__init__.py
@@ -1,1 +1,0 @@
-"""NHP Demand Model."""


### PR DESCRIPTION
there are a few things that are either no longer valid, or could cause issues as we introduce other packages using the nhp namespace.



* **remove top level init.py**
* **moves version into nhp.model**
* **name should be "nhp-model" and not "nhp\_model"**
* **do not need codecov.yml anymore**
