### PR TITLE
change fyear in generate_synthetic_datasets notebook

### DIFF
--- a/notebooks/generate_synthetic_datasets.ipynb
+++ b/notebooks/generate_synthetic_datasets.ipynb
@@ -26,12 +26,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "path = \"../data/dev\"\n",
-    "fyear = 2019"
+    "fyear = 2023"
    ]
   },
   {
@@ -182,7 +182,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "nhp_model",
    "language": "python",
    "name": "python3"
   },
@@ -196,7 +196,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.4"
+   "version": "3.11.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Since v4.0, 2019 baseline year is not possible. Updates synthetic data generation notebook