### PR TITLE
fix bug in inequalities for PBM notebook

### DIFF
--- a/src/nhp/model/data/databricks.py
+++ b/src/nhp/model/data/databricks.py
@@ -341,6 +341,8 @@ class DatabricksNational(Data):
         :return: the inequalities dataframe
         :rtype: pd.DataFrame
         """
-        return self._spark.read.table("nhp.default.inequalities").filter(
-            F.col("fyear") == self._year * 100 + (self._year + 1) % 100
+        return (
+            self._spark.read.table("nhp.default.inequalities")
+            .filter(F.col("fyear") == self._year * 100 + (self._year + 1) % 100)
+            .toPandas()
         )


### PR DESCRIPTION
Kind of redundant as inequalities is not working for anything other than provider level model runs - but this stops the current iteration of the national model notebook from running at all