### PR TITLE
switches to using spawn multiprocessing

### DIFF
--- a/src/nhp/model/run.py
+++ b/src/nhp/model/run.py
@@ -1,9 +1,9 @@
 """Run the model."""
 
 import logging
+import multiprocessing
 import os
 import time
-from multiprocessing import Pool
 from typing import Any, Callable, Tuple, Type
 
 from tqdm.auto import tqdm as base_tqdm
@@ -84,7 +84,8 @@ def _run_model(
     cpus = os.cpu_count()
     batch_size = int(os.getenv("BATCH_SIZE", "1"))
 
-    with Pool(cpus) as pool:
+    ctx = multiprocessing.get_context("spawn")
+    with ctx.Pool(cpus) as pool:
         baseline = model.go(0)  # baseline
         model_results: list[ModelRunResult] = list(
             tqdm(


### PR DESCRIPTION
on \*nix the default is to use fork, but this raises some warnings as there is a mixture of threads and forks. this forces us to use the spawn method instead.



see https://github.com/The-Strategy-Unit/nhp\_model/issues/449

