### PR TITLE
adds fallback version number

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,10 +17,6 @@ RUN uv sync --frozen --no-dev --no-install-project
 # Ensure Python can find installed packages and local model
 ENV PATH="/app/.venv/bin:$PATH"
 
-# TODO: in order to build the docker container, we need to force the version number
-# might be worth building the .whl and copying that into the container instead
-ENV SETUPTOOLS_SCM_PRETEND_VERSION=v0.0.0
-
 # Copy application code (changes most frequently)
 COPY --chown=nhp:nhp src/nhp/ /app/src/nhp/
 RUN uv pip install .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,7 @@ line-ending = "auto"
 
 [tool.setuptools_scm]
 version_file = "src/nhp/model/_version.py"
+fallback_version = "0.0.0"
 
 [tool.ty.src]
 exclude = ["notebooks", "docs"]


### PR DESCRIPTION
dependabot is failing because there are no tags available for it to use for the version number. adding a fallback solves that issue, and removes the need to bodge it in the dockerfile
