### PR TITLE
fixes bug causing nhp_model_databricks not to run national model

### DIFF
--- a/src/nhp/model/data/databricks.py
+++ b/src/nhp/model/data/databricks.py
@@ -147,6 +147,18 @@ class Databricks(Data):
         # this is not supported in our data bricks environment currently
         raise NotImplementedError
 
+    def get_inequalities(self) -> pd.DataFrame:
+        """Get the inequalities dataframe.
+
+        Returns:
+            The inequalities dataframe.
+        """
+        return (
+            self._spark.read.table("nhp.default.inequalities")
+            .filter(F.col("fyear") == self._year * 100 + (self._year + 1) % 100)
+            .toPandas()
+        )
+
 
 class DatabricksNational(Data):
     """Load NHP data from databricks."""


### PR DESCRIPTION
I'm hoping this fixes the bug? 

bug error message:
```
----> 1 saved_files, json_filename = run_all(params, nhp_data, save_full_model_results=save_full_model_results)
      2 print(f"saved files: {saved_files}")
      3 print(f"json path: {json_filename}")
File /local_disk0/.ephemeral_nfs/cluster_libraries/python/lib/python3.12/site-packages/nhp/model/data/data.py:93, in Data.get_inequalities(self)
     87 def get_inequalities(self) -> pd.DataFrame:
     88     """Get the inequalities dataframe.
     89 
     90     Returns:
     91         The inequalities dataframe.
     92     """
---> 93     raise NotImplementedError()
```