### PR TITLE
fixes issue with loading hsa_gams.pkl

### DIFF
--- a/src/nhp/model/data/local.py
+++ b/src/nhp/model/data/local.py
@@ -101,7 +101,8 @@ class Local(Data):
         Returns:
             The health status adjustment gams.
         """
-        with open(f"{self._data_path}/hsa_gams.pkl", "rb") as hsa_pkl:
+        file = f"{self._file_path('hsa_gams')}/hsa_gams.pkl"
+        with open(file, "rb") as hsa_pkl:
             return pickle.load(hsa_pkl)
 
     def get_inequalities(self) -> pd.DataFrame:

--- a/tests/unit/nhp/model/data/test_local.py
+++ b/tests/unit/nhp/model/data/test_local.py
@@ -149,7 +149,7 @@ def test_get_hsa_gams(mocker):
 
     # assert
     assert actual == "data"
-    mock_file.assert_called_with("data/hsa_gams.pkl", "rb")
+    mock_file.assert_called_with("data/hsa_gams/fyear=2019/dataset=synthetic/hsa_gams.pkl", "rb")
     m.assert_called_once_with(mock_file())
 
 


### PR DESCRIPTION
not loading from correct path, should of been using the partitioned filesystem.

This bug has been present for a while, but hasn't surfaced because we do not typically use the gams directly, instead relying on the interpolated activity tables instead