### PR TITLE
separate storage accounts

### DIFF
--- a/src/nhp/docker/config.py
+++ b/src/nhp/docker/config.py
@@ -14,7 +14,14 @@ class Config:
 
         self._app_version = os.environ.get("APP_VERSION", "dev")
         self._data_version = os.environ.get("DATA_VERSION", "dev")
-        self._storage_account = os.environ.get("STORAGE_ACCOUNT")
+
+        self._queue_storage_account = os.environ.get("QUEUE_STORAGE_ACCOUNT")
+        self._data_storage_account = os.environ.get("DATA_STORAGE_ACCOUNT")
+        self._results_storage_account = os.environ.get("RESULTS_STORAGE_ACCOUNT")
+        self._full_model_results_storage_account = os.environ.get(
+            "FULL_MODEL_RESULTS_STORAGE_ACCOUNT"
+        )
+        self._model_runs_table_storage_account = os.environ.get("MODEL_RUNS_TABLE_STORAGE_ACCOUNT")
 
     @property
     def APP_VERSION(self) -> str:
@@ -27,8 +34,36 @@ class Config:
         return self._data_version
 
     @property
-    def STORAGE_ACCOUNT(self) -> str:
-        """What is the name of the storage account?"""
-        if self._storage_account is None:
-            raise ValueError("STORAGE_ACCOUNT environment variable must be set")
-        return self._storage_account
+    def QUEUE_STORAGE_ACCOUNT(self) -> str:
+        """What is the name of the storage account for the queue container?"""
+        if self._queue_storage_account is None:
+            raise ValueError("QUEUE_STORAGE_ACCOUNT environment variable must be set")
+        return self._queue_storage_account
+
+    @property
+    def DATA_STORAGE_ACCOUNT(self) -> str:
+        """What is the name of the storage account for the data container?"""
+        if self._data_storage_account is None:
+            raise ValueError("DATA_STORAGE_ACCOUNT environment variable must be set")
+        return self._data_storage_account
+
+    @property
+    def RESULTS_STORAGE_ACCOUNT(self) -> str:
+        """What is the name of the storage account for the results container?"""
+        if self._results_storage_account is None:
+            raise ValueError("RESULTS_STORAGE_ACCOUNT environment variable must be set")
+        return self._results_storage_account
+
+    @property
+    def FULL_MODEL_RESULTS_STORAGE_ACCOUNT(self) -> str:
+        """What is the name of the storage account for the full model results container?"""
+        if self._full_model_results_storage_account is None:
+            raise ValueError("FULL_MODEL_RESULTS_STORAGE_ACCOUNT environment variable must be set")
+        return self._full_model_results_storage_account
+
+    @property
+    def MODEL_RUNS_TABLE_STORAGE_ACCOUNT(self) -> str:
+        """What is the name of the storage account for the model runs table?"""
+        if self._model_runs_table_storage_account is None:
+            raise ValueError("MODEL_RUNS_TABLE_STORAGE_ACCOUNT environment variable must be set")
+        return self._model_runs_table_storage_account

--- a/src/nhp/docker/config.py
+++ b/src/nhp/docker/config.py
@@ -15,13 +15,21 @@ class Config:
         self._app_version = os.environ.get("APP_VERSION", "dev")
         self._data_version = os.environ.get("DATA_VERSION", "dev")
 
-        self._queue_storage_account = os.environ.get("QUEUE_STORAGE_ACCOUNT")
-        self._data_storage_account = os.environ.get("DATA_STORAGE_ACCOUNT")
-        self._results_storage_account = os.environ.get("RESULTS_STORAGE_ACCOUNT")
-        self._full_model_results_storage_account = os.environ.get(
-            "FULL_MODEL_RESULTS_STORAGE_ACCOUNT"
+        default_storage_account = os.environ.get("STORAGE_ACCOUNT")
+
+        self._queue_storage_account = os.environ.get(
+            "QUEUE_STORAGE_ACCOUNT", default_storage_account
         )
-        self._model_runs_table_storage_account = os.environ.get("MODEL_RUNS_TABLE_STORAGE_ACCOUNT")
+        self._data_storage_account = os.environ.get("DATA_STORAGE_ACCOUNT", default_storage_account)
+        self._results_storage_account = os.environ.get(
+            "RESULTS_STORAGE_ACCOUNT", default_storage_account
+        )
+        self._full_model_results_storage_account = os.environ.get(
+            "FULL_MODEL_RESULTS_STORAGE_ACCOUNT", default_storage_account
+        )
+        self._model_runs_table_storage_account = os.environ.get(
+            "MODEL_RUNS_TABLE_STORAGE_ACCOUNT", default_storage_account
+        )
 
     @property
     def APP_VERSION(self) -> str:

--- a/src/nhp/docker/run.py
+++ b/src/nhp/docker/run.py
@@ -12,7 +12,7 @@ from uuid import UUID
 import pandas as pd
 from azure.data.tables import TableServiceClient, UpdateMode
 from azure.identity import DefaultAzureCredential
-from azure.storage.blob import BlobServiceClient
+from azure.storage.blob import ContainerClient
 from azure.storage.filedatalake import DataLakeServiceClient
 
 from nhp.docker.config import Config
@@ -90,31 +90,22 @@ class RunWithAzureStorage:
 
         self._app_version = re.sub("(\\d+\\.\\d+)\\..*", "\\1", self._config.APP_VERSION)
 
-        self._blob_storage_account_url = (
-            f"https://{self._config.STORAGE_ACCOUNT}.blob.core.windows.net"
-        )
-        self._adls_storage_account_url = (
-            f"https://{self._config.STORAGE_ACCOUNT}.dfs.core.windows.net"
-        )
-        self._table_storage_account_url = (
-            f"https://{self._config.STORAGE_ACCOUNT}.table.core.windows.net"
-        )
-
         self.params = self._get_params(filename)
         self._get_data(self.params["start_year"], self.params["dataset"])
 
         self._table_client = TableServiceClient(
-            endpoint=self._table_storage_account_url,
+            endpoint=self._config.MODEL_RUNS_TABLE_STORAGE_ACCOUNT,
             credential=DefaultAzureCredential(),
         ).get_table_client("modelruns")
 
         self._update_table_storage(status="running")
 
-    def _get_container(self, container_name: str):
-        return BlobServiceClient(
-            account_url=self._blob_storage_account_url,
+    def _get_container(self, account_name: str, container_name: str):
+        return ContainerClient(
+            account_url=f"https://{account_name}.blob.core.windows.net",
+            container_name=container_name,
             credential=DefaultAzureCredential(),
-        ).get_container_client(container_name)
+        )
 
     def _get_params(self, filename: str) -> dict:
         """Get the parameters for the model.
@@ -127,7 +118,9 @@ class RunWithAzureStorage:
         """
         logging.info("downloading params: %s", filename)
 
-        self._queue_blob = self._get_container("queue").get_blob_client(filename)
+        self._queue_blob = self._get_container(
+            self._config.QUEUE_STORAGE_ACCOUNT, "queue"
+        ).get_blob_client(filename)
 
         params_content = self._queue_blob.download_blob().readall()
 
@@ -144,7 +137,7 @@ class RunWithAzureStorage:
         """
         logging.info("downloading data (%s / %s)", year, dataset)
         fs_client = DataLakeServiceClient(
-            account_url=self._adls_storage_account_url,
+            account_url=f"https://{self._config.DATA_STORAGE_ACCOUNT}.dfs.core.windows.net",
             credential=DefaultAzureCredential(),
         ).get_file_system_client("data")
 
@@ -179,7 +172,7 @@ class RunWithAzureStorage:
             metadata: The metadata to attach to the blob.
             variants: A list of the variants that were run.
         """
-        container = self._get_container("results")
+        container = self._get_container(self._config.RESULTS_STORAGE_ACCOUNT, "results")
 
         results_file = generate_results_json(results, self.params, variants)
 
@@ -215,7 +208,7 @@ class RunWithAzureStorage:
             variants: A list of the variants that were run.
         """
         params = self.params
-        container = self._get_container("results")
+        container = self._get_container(self._config.RESULTS_STORAGE_ACCOUNT, "results")
         for k, v in results.items():
             container.upload_blob(
                 file_path + f"/{k}.parquet",
@@ -237,7 +230,7 @@ class RunWithAzureStorage:
         )
 
     def _upload_full_model_results(self) -> None:
-        container = self._get_container("results")
+        container = self._get_container(self._config.FULL_MODEL_RESULTS_STORAGE_ACCOUNT, "results")
 
         dataset = self.params["dataset"]
         scenario = self.params["scenario"]

--- a/src/nhp/docker/run.py
+++ b/src/nhp/docker/run.py
@@ -94,7 +94,7 @@ class RunWithAzureStorage:
         self._get_data(self.params["start_year"], self.params["dataset"])
 
         self._table_client = TableServiceClient(
-            endpoint=self._config.MODEL_RUNS_TABLE_STORAGE_ACCOUNT,
+            endpoint=f"https://{self._config.MODEL_RUNS_TABLE_STORAGE_ACCOUNT}.table.core.windows.net",
             credential=DefaultAzureCredential(),
         ).get_table_client("modelruns")
 

--- a/src/nhp/model/results.py
+++ b/src/nhp/model/results.py
@@ -116,7 +116,6 @@ def generate_results_json(
     variants: list[str],
 ) -> str:
     """Generate the results in the json format and save."""
-    step_counts = results.pop("step_counts")
 
     def agg_to_dict(res):
         results_df = res.set_index("model_run")
@@ -137,10 +136,11 @@ def generate_results_json(
             .to_dict(orient="records")
         )
 
-    dict_results = {k: agg_to_dict(v) for k, v in results.items()}
+    dict_results = {k: agg_to_dict(v) for k, v in results.items() if k != "step_counts"}
 
     dict_results["step_counts"] = (
-        step_counts.groupby(
+        results["step_counts"]
+        .groupby(
             [
                 "pod",
                 "change_factor",

--- a/tests/unit/nhp/docker/test_config.py
+++ b/tests/unit/nhp/docker/test_config.py
@@ -16,7 +16,11 @@ def test_config_sets_values_from_envvars(mocker):
         {
             "APP_VERSION": "app version",
             "DATA_VERSION": "data version",
-            "STORAGE_ACCOUNT": "storage account",
+            "QUEUE_STORAGE_ACCOUNT": "queue storage account",
+            "DATA_STORAGE_ACCOUNT": "data storage account",
+            "RESULTS_STORAGE_ACCOUNT": "results storage account",
+            "FULL_MODEL_RESULTS_STORAGE_ACCOUNT": "full model results storage account",
+            "MODEL_RUNS_TABLE_STORAGE_ACCOUNT": "model runs table account",
         },
     ):
         config = Config()
@@ -24,7 +28,11 @@ def test_config_sets_values_from_envvars(mocker):
     # assert
     assert config.APP_VERSION == "app version"
     assert config.DATA_VERSION == "data version"
-    assert config.STORAGE_ACCOUNT == "storage account"
+    assert config.QUEUE_STORAGE_ACCOUNT == "queue storage account"
+    assert config.DATA_STORAGE_ACCOUNT == "data storage account"
+    assert config.RESULTS_STORAGE_ACCOUNT == "results storage account"
+    assert config.FULL_MODEL_RESULTS_STORAGE_ACCOUNT == "full model results storage account"
+    assert config.MODEL_RUNS_TABLE_STORAGE_ACCOUNT == "model runs table account"
 
 
 def test_config_uses_default_values(mocker):
@@ -38,8 +46,26 @@ def test_config_uses_default_values(mocker):
     assert config.APP_VERSION == "dev"
     assert config.DATA_VERSION == "dev"
 
-    with pytest.raises(ValueError, match="STORAGE_ACCOUNT environment variable must be set"):
-        config.STORAGE_ACCOUNT
+    with pytest.raises(ValueError, match="QUEUE_STORAGE_ACCOUNT environment variable must be set"):
+        config.QUEUE_STORAGE_ACCOUNT
+
+    with pytest.raises(ValueError, match="DATA_STORAGE_ACCOUNT environment variable must be set"):
+        config.DATA_STORAGE_ACCOUNT
+
+    with pytest.raises(
+        ValueError, match="RESULTS_STORAGE_ACCOUNT environment variable must be set"
+    ):
+        config.RESULTS_STORAGE_ACCOUNT
+
+    with pytest.raises(
+        ValueError, match="FULL_MODEL_RESULTS_STORAGE_ACCOUNT environment variable must be set"
+    ):
+        config.FULL_MODEL_RESULTS_STORAGE_ACCOUNT
+
+    with pytest.raises(
+        ValueError, match="MODEL_RUNS_TABLE_STORAGE_ACCOUNT environment variable must be set"
+    ):
+        config.MODEL_RUNS_TABLE_STORAGE_ACCOUNT
 
 
 def test_config_calls_dotenv_load(mocker):

--- a/tests/unit/nhp/docker/test_config.py
+++ b/tests/unit/nhp/docker/test_config.py
@@ -35,6 +35,27 @@ def test_config_sets_values_from_envvars(mocker):
     assert config.MODEL_RUNS_TABLE_STORAGE_ACCOUNT == "model runs table account"
 
 
+def test_config_uses_default_storage_account(mocker):
+    # arrange
+    mocker.patch("dotenv.load_dotenv")
+
+    # act
+    with patch.dict(
+        os.environ,
+        {
+            "STORAGE_ACCOUNT": "default storage account",
+        },
+    ):
+        config = Config()
+
+    # assert
+    assert config.QUEUE_STORAGE_ACCOUNT == "default storage account"
+    assert config.DATA_STORAGE_ACCOUNT == "default storage account"
+    assert config.RESULTS_STORAGE_ACCOUNT == "default storage account"
+    assert config.FULL_MODEL_RESULTS_STORAGE_ACCOUNT == "default storage account"
+    assert config.MODEL_RUNS_TABLE_STORAGE_ACCOUNT == "default storage account"
+
+
 def test_config_uses_default_values(mocker):
     # arrange
     mocker.patch("dotenv.load_dotenv")

--- a/tests/unit/nhp/docker/test_config.py
+++ b/tests/unit/nhp/docker/test_config.py
@@ -45,6 +45,7 @@ def test_config_uses_default_storage_account(mocker):
         {
             "STORAGE_ACCOUNT": "default storage account",
         },
+        clear=True,
     ):
         config = Config()
 

--- a/tests/unit/nhp/docker/test_run.py
+++ b/tests/unit/nhp/docker/test_run.py
@@ -77,11 +77,11 @@ def mock_run_with_azure_storage():
     rwas._config = Mock()
     rwas._config.APP_VERSION = "dev"
     rwas._config.DATA_VERSION = "dev"
-    rwas._config.STORAGE_ACCOUNT = "sa"
-
-    rwas._blob_storage_account_url = "https://sa.blob.core.windows.net"
-    rwas._adls_storage_account_url = "https://sa.dfs.core.windows.net"
-    rwas._table_storage_account_url = "https://sa.table.core.windows.net"
+    rwas._config.QUEUE_STORAGE_ACCOUNT = "queue-sa"
+    rwas._config.DATA_STORAGE_ACCOUNT = "data-sa"
+    rwas._config.RESULTS_STORAGE_ACCOUNT = "results-sa"
+    rwas._config.FULL_MODEL_RESULTS_STORAGE_ACCOUNT = "full-model-results-sa"
+    rwas._config.MODEL_RUNS_TABLE_STORAGE_ACCOUNT = "model-runs-table-sa"
     rwas._table_client = Mock()
 
     rwas.params = {"dataset": "test"}
@@ -95,6 +95,7 @@ def test_RunWithAzureStorage_init(mocker, actual_version, expected_version):
     config = mocker.patch("nhp.docker.run.Config")
     config().APP_VERSION = actual_version
     config().STORAGE_ACCOUNT = "sa"
+    config().MODEL_RUNS_TABLE_STORAGE_ACCOUNT = "https://sa.table.core.windows.net"
 
     expected_params = {"start_year": 2020, "dataset": "synthetic"}
     gpm = mocker.patch(
@@ -118,8 +119,6 @@ def test_RunWithAzureStorage_init(mocker, actual_version, expected_version):
     assert s._model_run_id == model_run_id
     assert s._app_version == expected_version
     assert s.params == expected_params
-    assert s._blob_storage_account_url == "https://sa.blob.core.windows.net"
-    assert s._adls_storage_account_url == "https://sa.dfs.core.windows.net"
     assert s._table_client is table_client
 
     gpm.assert_called_once_with("filename")
@@ -137,19 +136,20 @@ def test_RunWithAzureStorage_get_container(mock_run_with_azure_storage, mocker):
     # arrange
     s = mock_run_with_azure_storage
 
-    mock = Mock()
-    mock.get_container_client.return_value = "container_client"
-
-    bsc_m = mocker.patch("nhp.docker.run.BlobServiceClient", return_value=mock)
+    cc_m = mocker.patch("nhp.docker.run.ContainerClient", return_value="container_client")
 
     dac_m = mocker.patch("nhp.docker.run.DefaultAzureCredential", return_value="cred")
 
     # act
-    actual = s._get_container("container")
+    actual = s._get_container("sa", "container")
 
     # assert
     assert actual == "container_client"
-    bsc_m.assert_called_once_with(account_url="https://sa.blob.core.windows.net", credential="cred")
+    cc_m.assert_called_once_with(
+        account_url="https://sa.blob.core.windows.net",
+        container_name="container",
+        credential="cred",
+    )
     dac_m.assert_called_once_with()
 
 
@@ -175,7 +175,7 @@ def test_RunWithAzureStorage_get_params(mock_run_with_azure_storage, mocker):
     # assert
     assert actual == expected
 
-    m1.assert_called_once_with("queue")
+    m1.assert_called_once_with("queue-sa", "queue")
     assert s._queue_blob == m2
 
     m2.download_blob.assert_called_once_with()
@@ -214,7 +214,9 @@ def test_RunWithAzureStorage_get_data(mock_run_with_azure_storage, mocker):
         s._get_data(2020, "synthetic")
 
     # assert
-    dlsc_m.assert_called_once_with(account_url="https://sa.dfs.core.windows.net", credential="cred")
+    dlsc_m.assert_called_once_with(
+        account_url="https://data-sa.dfs.core.windows.net", credential="cred"
+    )
     dac_m.assert_called_once_with()
 
     mock.get_file_system_client.assert_called_once_with("data")
@@ -258,7 +260,7 @@ def test_RunWithAzureStorage_upload_results_json(mock_run_with_azure_storage, mo
 
     # assert
     mock_file.assert_called_once_with("results/filename.json", "rb")
-    m_get_container.assert_called_once_with("results")
+    m_get_container.assert_called_once_with("results-sa", "results")
     m_get_container().upload_blob.assert_called_once_with(
         "prod/dev/filename.json.gz",
         "gzdata",
@@ -285,7 +287,7 @@ def test_RunWithAzureStorage_upload_results_files(mock_run_with_azure_storage, m
     s._upload_results_files("file_path", {"a": results_file_mock}, metadata, ["variants"])
 
     # assert
-    get_container_mock.assert_called_once_with("results")
+    get_container_mock.assert_called_once_with("results-sa", "results")
     get_container_mock().upload_blob.assert_has_calls(
         [
             call(
@@ -335,7 +337,7 @@ def test_RunWithAzureStorage_upload_full_model_results(mock_run_with_azure_stora
     # assert
     assert mock_file.call_count == 3
     assert mock_file.call_args_list == [call(i, "rb") for i in file_mocks]
-    m.assert_called_once_with("results")
+    m.assert_called_once_with("full-model-results-sa", "results")
 
     assert m().upload_blob.call_count == 3
     assert m().upload_blob.call_args_list == [

--- a/tests/unit/nhp/docker/test_run.py
+++ b/tests/unit/nhp/docker/test_run.py
@@ -95,7 +95,7 @@ def test_RunWithAzureStorage_init(mocker, actual_version, expected_version):
     config = mocker.patch("nhp.docker.run.Config")
     config().APP_VERSION = actual_version
     config().STORAGE_ACCOUNT = "sa"
-    config().MODEL_RUNS_TABLE_STORAGE_ACCOUNT = "https://sa.table.core.windows.net"
+    config().MODEL_RUNS_TABLE_STORAGE_ACCOUNT = "sa"
 
     expected_params = {"start_year": 2020, "dataset": "synthetic"}
     gpm = mocker.patch(


### PR DESCRIPTION
adds extra environment variables to allow us to use different storage accounts for each container. the old environment variable is used as a default, so we can continue to set just a single value to control all.
