### PR TITLE
fix: prevent race condition in schema deployment, add manual trigger

### DIFF
--- a/.github/workflows/build_schema.yaml
+++ b/.github/workflows/build_schema.yaml
@@ -4,12 +4,7 @@ on:
   workflow_call:
     inputs:
       schema-tag:
-        default: dev
-        type: string
-  workflow_dispatch:
-    inputs:
-      schema-tag:
-        default: dev
+        required: true
         type: string
 
 concurrency:
@@ -17,8 +12,6 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  pages: write
-  id-token: write
   contents: write
 
 jobs:
@@ -48,18 +41,3 @@ jobs:
           git push origin schemas
           popd
 
-      - name: Upload to GitHub Pages
-        uses: actions/upload-pages-artifact@v4
-        with:
-          path: schemas
-
-  deploy:
-    needs: build
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4

--- a/.github/workflows/build_schema.yaml
+++ b/.github/workflows/build_schema.yaml
@@ -4,9 +4,17 @@ on:
   workflow_call:
     inputs:
       schema-tag:
-        required: true
         default: dev
         type: string
+  workflow_dispatch:
+    inputs:
+      schema-tag:
+        default: dev
+        type: string
+
+concurrency:
+  group: schema-deploy
+  cancel-in-progress: false
 
 permissions:
   pages: write


### PR DESCRIPTION
Closes #610

## Problem
When a tagged release is pushed to `main`, both `deploy_release.yaml` (triggered by the tag) and `deploy_dev.yaml` (triggered by the push to `main`) call `build_schema.yaml` simultaneously. If the `dev` run fetches the `schemas` branch before the release run has committed the new version folder, then deploys Pages after it, the release schema is silently overwritten.

Additionally, `build_schema.yaml` had no `workflow_dispatch` trigger, making it impossible to re-run manually from the Actions UI.

## Changes
- Add `concurrency` group (`schema-deploy`, non-cancelling) to serialise deployments and prevent the race condition
- Add `workflow_dispatch` trigger so the workflow can be run manually  with a specific `schema-tag` (e.g. to recover `v5.0`)

Opening as draft because I'd like to run the change locally with [act](https://nektosact.com/)) once I get hold of the env vars I'm missing. 
Edit: Please note that I haven't been able to test the changes locally due to Actions' complexity and some env vars I'm missing