### PR TITLE
renames variables for clarity

### DIFF
--- a/src/nhp/model/results.py
+++ b/src/nhp/model/results.py
@@ -68,10 +68,10 @@ def _combine_model_results(
     return {
         k: _complete_model_runs(
             [
-                v[k].reset_index().assign(model_run=i)
+                aggregated_results[k].reset_index().assign(model_run=i)
                 for r in results
-                for (i, (v, _)) in enumerate(r)
-                if k in v
+                for (i, (aggregated_results, _step_counts)) in enumerate(r)
+                if k in aggregated_results
             ],
             model_runs,
         )
@@ -94,15 +94,15 @@ def _combine_step_counts(results: list) -> pd.DataFrame:
     model_runs = len(results[0]) - 1
     return _complete_model_runs(
         [
-            v
+            step_counts
             # TODO: handle the case of daycase conversion, it's duplicating values
             # need to figure out exactly why, but this masks the issue for now
-            .groupby(v.index.names)
+            .groupby(step_counts.index.names)
             .sum()
             .reset_index()
             .assign(model_run=i)
             for r in results
-            for i, (_, v) in enumerate(r)
+            for i, (_aggregated_results, step_counts) in enumerate(r)
             if i > 0
         ],
         model_runs,

--- a/tests/e2e/test_run_model_snapshot/test_all_model_runs_step_counts_.csv
+++ b/tests/e2e/test_run_model_snapshot/test_all_model_runs_step_counts_.csv
@@ -1839,7 +1839,7 @@
 1837,op,a,op_procedure,health_status_adjustment,-,tele_attendances,0.0
 1838,op,a,op_procedure,inequalities,-,attendances,0.0
 1839,op,a,op_procedure,inequalities,-,tele_attendances,0.0
-1840,op,a,op_procedure,model_interaction_term,-,attendances,3607.4
+1840,op,a,op_procedure,model_interaction_term,-,attendances,3607.5
 1841,op,a,op_procedure,model_interaction_term,-,tele_attendances,0.0
 1842,op,a,op_procedure,non-demographic_adjustment,-,attendances,28952.1
 1843,op,a,op_procedure,non-demographic_adjustment,-,tele_attendances,0.0


### PR DESCRIPTION
in the _combine* functions we unpacked each model runs results tuple, but it wasn't immediately clear how we got the aggregated results or step counts. renamed for clarity.
