### PR TITLE
handles the case of running a model where a provider doesn't have A&E data

### DIFF
--- a/src/nhp/docker/__main__.py
+++ b/src/nhp/docker/__main__.py
@@ -88,6 +88,7 @@ def main(config: Config):
     except Exception as e:
         logging.error("An error occurred: %s", str(e))
         runner.error(str(e))
+        raise e
 
 
 def init():

--- a/src/nhp/docker/run.py
+++ b/src/nhp/docker/run.py
@@ -147,6 +147,11 @@ class RunWithAzureStorage:
 
         for p in paths:
             subpath = f"{p}/fyear={year}/dataset={dataset}"
+
+            if not fs_client.get_directory_client(subpath).exists():
+                logging.info("No data found for %s", subpath)
+                continue
+
             os.makedirs(f"data{subpath.removeprefix(version)}", exist_ok=True)
 
             for i in fs_client.get_paths(subpath):

--- a/src/nhp/docker/run.py
+++ b/src/nhp/docker/run.py
@@ -220,21 +220,21 @@ class RunWithAzureStorage:
         container = self._get_container(self._config.RESULTS_STORAGE_ACCOUNT, "results")
         logging.info("Uploading results files to blob storage: %s", file_path)
         for k, v in results.items():
-            logging.info(" * %s.parquet", k)
+            logging.debug(" * %s.parquet", k)
             container.upload_blob(
                 f"{file_path}/{k}.parquet",
                 v.to_parquet(index=False),
                 overwrite=True,
                 metadata=metadata,
             )
-        logging.info(" * params.json")
+        logging.debug(" * params.json")
         container.upload_blob(
             f"{file_path}/params.json",
             json.dumps(params).encode("utf-8"),
             overwrite=True,
             metadata=metadata,
         )
-        logging.info(" * variants.json")
+        logging.debug(" * variants.json")
         container.upload_blob(
             f"{file_path}/variants.json",
             json.dumps(variants).encode("utf-8"),
@@ -255,7 +255,7 @@ class RunWithAzureStorage:
         logging.info("Uploading full model results to blob storage: %s", path)
         for file in path.glob("**/*.parquet"):
             filename = file.as_posix()[8:]
-            logging.info(" * %s", filename)
+            logging.debug(" * %s", filename)
             with open(file, "rb") as f:
                 container.upload_blob(
                     f"full-model-results/{self._app_version}/{filename}",

--- a/src/nhp/docker/run.py
+++ b/src/nhp/docker/run.py
@@ -179,9 +179,11 @@ class RunWithAzureStorage:
         """
         container = self._get_container(self._config.RESULTS_STORAGE_ACCOUNT, "results")
 
+        logging.info("Generating results json file")
         results_file = generate_results_json(results, self.params, variants)
 
         results_json_gz_path = f"prod/{self._app_version}/{results_file}.json.gz"
+        logging.info("Uploading results json file to blob storage: %s", results_json_gz_path)
         with open(f"results/{results_file}.json", "rb") as file:
             container.upload_blob(
                 results_json_gz_path,
@@ -190,9 +192,11 @@ class RunWithAzureStorage:
                 overwrite=True,
             )
 
+        logging.info("Updating table storage with results json path: %s", results_json_gz_path)
         self._update_table_storage(
             results_json_gz_path=results_json_gz_path,
         )
+        logging.info("Results json file uploaded and table storage updated successfully.")
 
     def _upload_results_files(
         self,
@@ -214,25 +218,30 @@ class RunWithAzureStorage:
         """
         params = self.params
         container = self._get_container(self._config.RESULTS_STORAGE_ACCOUNT, "results")
+        logging.info("Uploading results files to blob storage: %s", file_path)
         for k, v in results.items():
+            logging.info(" * %s.parquet", k)
             container.upload_blob(
-                file_path + f"/{k}.parquet",
+                f"{file_path}/{k}.parquet",
                 v.to_parquet(index=False),
                 overwrite=True,
                 metadata=metadata,
             )
+        logging.info(" * params.json")
         container.upload_blob(
             f"{file_path}/params.json",
             json.dumps(params).encode("utf-8"),
             overwrite=True,
             metadata=metadata,
         )
+        logging.info(" * variants.json")
         container.upload_blob(
             f"{file_path}/variants.json",
             json.dumps(variants).encode("utf-8"),
             overwrite=True,
             metadata=metadata,
         )
+        logging.info("Results files uploaded successfully to blob storage: %s", file_path)
 
     def _upload_full_model_results(self) -> None:
         container = self._get_container(self._config.FULL_MODEL_RESULTS_STORAGE_ACCOUNT, "results")
@@ -243,14 +252,17 @@ class RunWithAzureStorage:
 
         path = Path(f"results/{dataset}/{scenario}/{create_datetime}")
 
+        logging.info("Uploading full model results to blob storage: %s", path)
         for file in path.glob("**/*.parquet"):
             filename = file.as_posix()[8:]
+            logging.info(" * %s", filename)
             with open(file, "rb") as f:
                 container.upload_blob(
                     f"full-model-results/{self._app_version}/{filename}",
                     f.read(),
                     overwrite=True,
                 )
+        logging.info("Full model results uploaded successfully to blob storage: %s", path)
 
     def _update_table_storage(self, **kwargs) -> None:
         """Update the table storage with the given data."""

--- a/src/nhp/model/aae.py
+++ b/src/nhp/model/aae.py
@@ -20,7 +20,7 @@ class AaEModel(Model):
 
     Args:
         params: The parameters to run the model with, or the path to a params file to load.
-        data: A callable that creates a Data instance.
+        data_loader: A Data instance.
         hsa: An instance of the HealthStatusAdjustment class. If left as None an instance is
             created. Defaults to None.
         run_params: The parameters to use for each model run. Generated automatically if left as
@@ -32,7 +32,7 @@ class AaEModel(Model):
     def __init__(
         self,
         params: dict | str,
-        data: Callable[[int, str], Data],
+        data_loader: Data,
         hsa: Any = None,
         run_params: dict | None = None,
         save_full_model_results: bool = False,
@@ -42,7 +42,7 @@ class AaEModel(Model):
 
         Args:
             params: The parameters to use.
-            data: A method to create a Data instance.
+            data_loader: A Data instance.
             hsa: Health Status Adjustment object. Defaults to None.
             run_params: The run parameters to use. Defaults to None.
             save_full_model_results: Whether to save full model results. Defaults to False.
@@ -53,7 +53,7 @@ class AaEModel(Model):
             "aae",
             ["arrivals"],
             params,
-            data,
+            data_loader,
             hsa,
             run_params,
             save_full_model_results,

--- a/src/nhp/model/data/data.py
+++ b/src/nhp/model/data/data.py
@@ -69,10 +69,10 @@ class Data:
         raise NotImplementedError()
 
     def get_hsa_activity_table(self) -> pd.DataFrame:
-        """Get the demographic factors dataframe.
+        """Get the health status adjustment activity table dataframe.
 
         Returns:
-            The demographic factors dataframe.
+            The health status adjustment activity table dataframe.
         """
         raise NotImplementedError()
 
@@ -89,5 +89,16 @@ class Data:
 
         Returns:
             The inequalities dataframe.
+        """
+        raise NotImplementedError()
+
+    def data_exists_for_model_type(self, model_type: Any) -> bool:
+        """Check if data exists for a given model type.
+
+        Args:
+            model_type: The model type to check.
+
+        Returns:
+            True if data exists for the given model type, False otherwise.
         """
         raise NotImplementedError()

--- a/src/nhp/model/data/local.py
+++ b/src/nhp/model/data/local.py
@@ -4,6 +4,7 @@ Classes for loading data for the NHP model. Each class supports loading data fro
 such as from local storage or directly from DataBricks.
 """
 
+import os
 import pickle
 from typing import Any, Callable
 
@@ -124,3 +125,24 @@ class Local(Data):
         """
         inequalities_df = pd.read_parquet(self._file_path(file))
         return inequalities_df
+
+    def data_exists_for_model_type(self, model_type: Any) -> bool:
+        """Check if data exists for a specific model type.
+
+        Args:
+            model_type: The model type to check for.
+
+        Returns:
+            True if data exists for the model type, False otherwise.
+        """
+        match model_type.__name__:
+            case "InpatientsModel":
+                path = self._file_path("ip")
+            case "OutpatientsModel":
+                path = self._file_path("op")
+            case "AaEModel":
+                path = self._file_path("aae")
+            case _:
+                raise ValueError(f"Unknown model type: {model_type.__name__}")
+
+        return os.path.exists(path)

--- a/src/nhp/model/inpatients.py
+++ b/src/nhp/model/inpatients.py
@@ -21,7 +21,7 @@ class InpatientsModel(Model):
 
     Args:
         params: The parameters to run the model with, or the path to a params file to load.
-        data: A callable that creates a Data instance.
+        data_loader: A Data instance.
         hsa: An instance of the HealthStatusAdjustment class. If left as None an instance is
             created. Defaults to None.
         run_params: The parameters to use for each model run. Generated automatically if left as
@@ -33,7 +33,7 @@ class InpatientsModel(Model):
     def __init__(
         self,
         params: dict | str,
-        data: Callable[[int, str], Data],
+        data_loader: Data,
         hsa: Any = None,
         run_params: dict | None = None,
         save_full_model_results: bool = False,
@@ -43,7 +43,7 @@ class InpatientsModel(Model):
 
         Args:
             params: The parameters to use.
-            data: A method to create a Data instance.
+            data_loader: A Data instance.
             hsa: Health Status Adjustment object. Defaults to None.
             run_params: The run parameters to use. Defaults to None.
             save_full_model_results: Whether to save full model results. Defaults to False.
@@ -54,7 +54,7 @@ class InpatientsModel(Model):
             "ip",
             ["admissions", "beddays"],
             params,
-            data,
+            data_loader,
             hsa,
             run_params,
             save_full_model_results,

--- a/src/nhp/model/model.py
+++ b/src/nhp/model/model.py
@@ -37,7 +37,7 @@ class Model:
         model_type: The type of model, either "aae", "ip", or "op".
         measures: The names of the measures in the model.
         params: The parameters to run the model with, or the path to a params file to load.
-        data: A callable that creates a Data instance.
+        data_loader: A Data instance.
         hsa: An instance of the HealthStatusAdjustment class. If left as None an instance is
             created. Defaults to None.
         run_params: The parameters to use for each model run. Generated automatically if left as
@@ -64,7 +64,7 @@ class Model:
         model_type: str,
         measures: List[str],
         params: dict | str,
-        data: Callable[[int, str], Data],
+        data_loader: Data,
         hsa: Any | None = None,
         run_params: dict | None = None,
         save_full_model_results: bool = False,
@@ -76,7 +76,7 @@ class Model:
             model_type: A string saying what type of model this is.
             measures: The names of the measures in this model type.
             params: The parameters to use.
-            data: A method to create a Data instance.
+            data_loader: A Data instance.
             hsa: Health Status Adjustment object. Defaults to None.
             run_params: The run parameters to use. Defaults to None.
             save_full_model_results: Whether to save full model results. Defaults to False.
@@ -92,8 +92,6 @@ class Model:
         # add model runtime if it doesn't exist
         if "create_datetime" not in self.params:
             self.params["create_datetime"] = f"{datetime.now():%Y%m%d_%H%M%S}"
-
-        data_loader = data(params["start_year"], params["dataset"])
 
         self._measures = measures
         # load the data. we only need some of the columns for the model, so just load what we need

--- a/src/nhp/model/outpatients.py
+++ b/src/nhp/model/outpatients.py
@@ -20,7 +20,7 @@ class OutpatientsModel(Model):
 
     Args:
         params: The parameters to run the model with, or the path to a params file to load.
-        data: A callable that creates a Data instance.
+        data_loader: A Data instance.
         hsa: An instance of the HealthStatusAdjustment class. If left as None an instance is
             created. Defaults to None.
         run_params: The parameters to use for each model run. Generated automatically if left as
@@ -32,7 +32,7 @@ class OutpatientsModel(Model):
     def __init__(
         self,
         params: dict | str,
-        data: Callable[[int, str], Data],
+        data_loader: Data,
         hsa: Any = None,
         run_params: dict | None = None,
         save_full_model_results: bool = False,
@@ -42,7 +42,7 @@ class OutpatientsModel(Model):
 
         Args:
             params: The parameters to use.
-            data: A method to create a Data instance.
+            data_loader: A Data instance.
             hsa: Health Status Adjustment object. Defaults to None.
             run_params: The run parameters to use. Defaults to None.
             save_full_model_results: Whether to save full model results. Defaults to False.
@@ -53,7 +53,7 @@ class OutpatientsModel(Model):
             "op",
             ["attendances", "tele_attendances"],
             params,
-            data,
+            data_loader,
             hsa,
             run_params,
             save_full_model_results,

--- a/src/nhp/model/results.py
+++ b/src/nhp/model/results.py
@@ -257,6 +257,9 @@ def _patch_converted_sdec_activity(
     results: Dict[str, pd.DataFrame], column: str, col_value: str
 ) -> None:
     """Patch the converted SDEC activity in the dataframe."""
+    if column not in results:
+        return
+
     results_df = results[column]
     agg_cols = ["pod", "sitetret", "measure", "model_run"]
 

--- a/src/nhp/model/results.py
+++ b/src/nhp/model/results.py
@@ -126,7 +126,9 @@ def generate_results_json(
             .to_dict(orient="records")
         )
 
-    dict_results = {k: agg_to_dict(v) for k, v in results.items() if k != "step_counts"}
+    dict_results = {
+        k: agg_to_dict(v) for k, v in results.items() if k != "step_counts" if len(v) > 0
+    }
 
     dict_results["step_counts"] = (
         results["step_counts"]

--- a/src/nhp/model/run.py
+++ b/src/nhp/model/run.py
@@ -164,6 +164,7 @@ def run_all(
                 aggregation_columns,
             )
             for m in model_types
+            if nhp_data.data_exists_for_model_type(m)
         ]
     )
 

--- a/src/nhp/model/run.py
+++ b/src/nhp/model/run.py
@@ -45,7 +45,7 @@ def timeit(func: Callable, *args, **kwargs) -> Any:
 def _run_model(
     model_type: Type[Model],
     params: dict,
-    data: Callable[[int, str], Data],
+    data: Data,
     hsa: Any,
     run_params: dict,
     progress_callback: Callable[[Any], None],
@@ -59,7 +59,7 @@ def _run_model(
     Args:
         model_type: The type of model that we want to run.
         params: The parameters to run the model with.
-        data: A callable that creates a Data instance.
+        data: A Data instance.
         hsa: An instance of the HealthStatusAdjustment class.
         run_params: The generated run parameters for the model run.
         progress_callback: A callback function for progress updates.
@@ -116,7 +116,7 @@ def noop_progress_callback(_: Any) -> Callable[[Any], None]:
 
 def run_all(
     params: dict,
-    nhp_data: Callable[[int, str], Data],
+    nhp_data: Data | Callable[[int, str], Data],
     progress_callback: Callable[[Any], Callable[[Any], None]] = noop_progress_callback,
     save_full_model_results: bool = False,
     aggregation_columns: list[str] | None = None,
@@ -139,9 +139,12 @@ def run_all(
     model_types = [InpatientsModel, OutpatientsModel, AaEModel]
     run_params = Model.generate_run_params(params)
 
+    if not isinstance(nhp_data, Data):
+        nhp_data = nhp_data(params["start_year"], params["dataset"])
+
     # set the data path in the HealthStatusAdjustment class
     hsa = HealthStatusAdjustmentInterpolated(
-        nhp_data(params["start_year"], params["dataset"]),
+        nhp_data,
         params["start_year"],
         params["end_year"],
         params["seed"],
@@ -175,7 +178,7 @@ def run_single_model_run(
     aggregation_columns: list[str] | None = None,
 ) -> None:
     """Runs a single model iteration for easier debugging in vscode."""
-    data = Local.create(data_path)
+    data = Local(data_path, params["start_year"], params["dataset"])
 
     print("initialising model...  ", end="")
     model = timeit(model_type, params, data, aggregation_columns=aggregation_columns)

--- a/tests/e2e/test_run_model_snapshot.py
+++ b/tests/e2e/test_run_model_snapshot.py
@@ -24,14 +24,14 @@ def model_results(data_dir):
     # test them, but
     # TODO: refactor run_all to separate the logic of running the model and saving results
     params = load_sample_params(model_runs=32)
-    nhp_data = Local.create(data_dir)
+    nhp_data = Local(data_dir, params["start_year"], params["dataset"])
 
     model_types = [InpatientsModel, OutpatientsModel, AaEModel]
     run_params = Model.generate_run_params(params)
 
     # set the data path in the HealthStatusAdjustment class
     hsa = HealthStatusAdjustmentInterpolated(
-        nhp_data(params["start_year"], params["dataset"]),
+        nhp_data,
         params["start_year"],
         params["end_year"],
         params["seed"],

--- a/tests/integration/nhp/model/test_single_model_run.py
+++ b/tests/integration/nhp/model/test_single_model_run.py
@@ -15,7 +15,7 @@ from nhp.model.data import Local
 @pytest.fixture(scope="session")
 def model_single_run_results(data_dir):
     params = load_sample_params()
-    data = Local.create(data_dir)
+    data = Local(data_dir, params["start_year"], params["dataset"])
 
     results = {}
     for k, model_class in [("ip", InpatientsModel), ("op", OutpatientsModel), ("aae", AaEModel)]:

--- a/tests/unit/nhp/docker/test___main__.py
+++ b/tests/unit/nhp/docker/test___main__.py
@@ -221,7 +221,8 @@ def test_main_calls_runner_error_on_exception(mocker, local_storage):
     config = Mock()
 
     # act
-    main(config)
+    with pytest.raises(Exception, match="Test error"):
+        main(config)
 
     # assert
     if local_storage:

--- a/tests/unit/nhp/docker/test_run.py
+++ b/tests/unit/nhp/docker/test_run.py
@@ -249,6 +249,40 @@ def test_RunWithAzureStorage_get_data(mock_run_with_azure_storage, mocker):
 
 
 @pytest.mark.unit
+def test_RunWithAzureStorage_get_data_skips_missing_directory(mock_run_with_azure_storage, mocker):
+    # arrange
+    s = mock_run_with_azure_storage
+
+    path = Mock()
+    path.name = "dev/ip"
+
+    fs_client = Mock()
+    fs_client.get_file_system_client.return_value = fs_client
+    fs_client.get_paths.side_effect = [[path]]
+    fs_client.get_directory_client.return_value.exists.return_value = False
+
+    dlsc_m = mocker.patch("nhp.docker.run.DataLakeServiceClient", return_value=fs_client)
+    dac_m = mocker.patch("nhp.docker.run.DefaultAzureCredential", return_value="cred")
+    mkdir_m = mocker.patch("os.makedirs")
+
+    # act
+    with patch("builtins.open", mock_open()) as mock_file:
+        s._get_data(2020, "synthetic")
+
+    # assert
+    dlsc_m.assert_called_once_with(
+        account_url="https://data-sa.dfs.core.windows.net", credential="cred"
+    )
+    dac_m.assert_called_once_with()
+    fs_client.get_file_system_client.assert_called_once_with("data")
+    fs_client.get_paths.assert_called_once_with("dev", recursive=False)
+    fs_client.get_directory_client.assert_called_once_with("dev/ip/fyear=2020/dataset=synthetic")
+    mkdir_m.assert_not_called()
+    fs_client.get_file_client.assert_not_called()
+    mock_file.assert_not_called()
+
+
+@pytest.mark.unit
 def test_RunWithAzureStorage_upload_results_json(mock_run_with_azure_storage, mocker):
     # arrange
     s = mock_run_with_azure_storage

--- a/tests/unit/nhp/model/data/test_data.py
+++ b/tests/unit/nhp/model/data/test_data.py
@@ -66,3 +66,10 @@ def test_get_inequalities():
     d = Data()
     with pytest.raises(NotImplementedError):
         d.get_inequalities()
+
+
+@pytest.mark.unit
+def test_data_exists_for_model_type():
+    d = Data()
+    with pytest.raises(NotImplementedError):
+        d.data_exists_for_model_type("model_type")

--- a/tests/unit/nhp/model/data/test_local.py
+++ b/tests/unit/nhp/model/data/test_local.py
@@ -193,3 +193,37 @@ def test_get_parquet(mocker):
     assert actual == "data"
     fp.assert_called_once_with("file")
     m.assert_called_once_with("file_path")
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("model_name", "expected_path"),
+    [
+        ("InpatientsModel", "data/ip/fyear=2019/dataset=synthetic"),
+        ("OutpatientsModel", "data/op/fyear=2019/dataset=synthetic"),
+        ("AaEModel", "data/aae/fyear=2019/dataset=synthetic"),
+    ],
+)
+def test_data_exists_for_model_type(mocker, model_name, expected_path):
+    # arrange
+    exists_mock = mocker.patch("os.path.exists", return_value=True)
+    d = Local("data", 2019, "synthetic")
+    model_type = type(model_name, (), {})
+
+    # act
+    actual = d.data_exists_for_model_type(model_type)
+
+    # assert
+    assert actual is True
+    exists_mock.assert_called_once_with(expected_path)
+
+
+@pytest.mark.unit
+def test_data_exists_for_model_type_raises_for_unknown_model_type():
+    # arrange
+    d = Local("data", 2019, "synthetic")
+    model_type = type("UnknownModel", (), {})
+
+    # act/assert
+    with pytest.raises(ValueError, match="Unknown model type: UnknownModel"):
+        d.data_exists_for_model_type(model_type)

--- a/tests/unit/nhp/model/test_model.py
+++ b/tests/unit/nhp/model/test_model.py
@@ -144,7 +144,6 @@ def test_model_init_sets_values(mocker, model_type):
     lp_m = mocker.patch("nhp.model.model.load_params")
     hsa_m = mocker.patch("nhp.model.model.HealthStatusAdjustmentInterpolated")
     data_mock = Mock()
-    data_mock.return_value = "data_loader"
 
     # act
     mdl = Model(model_type, ["measures"], params, data_mock, "hsa", "run_params")  # type: ignore
@@ -152,11 +151,11 @@ def test_model_init_sets_values(mocker, model_type):
     # assert
     assert mdl.model_type == model_type
     assert mdl.params == params
-    data_mock.assert_called_once_with("2020", "synthetic")
-    mdl._load_data.assert_called_once_with("data_loader")  # type: ignore
-    mdl._load_strategies.assert_called_once_with("data_loader")  # type: ignore
-    mdl._load_demog_factors.assert_called_once_with("data_loader")  # type: ignore
-    mdl._load_inequalities_factors.assert_called_once_with("data_loader")  # type: ignore
+    data_mock.assert_not_called()
+    mdl._load_data.assert_called_once_with(data_mock)  # type: ignore
+    mdl._load_strategies.assert_called_once_with(data_mock)  # type: ignore
+    mdl._load_demog_factors.assert_called_once_with(data_mock)  # type: ignore
+    mdl._load_inequalities_factors.assert_called_once_with(data_mock)  # type: ignore
     assert mdl.hsa == "hsa"
     mdl.generate_run_params.assert_not_called()  # type: ignore
     assert mdl.run_params == "run_params"
@@ -270,10 +269,11 @@ def test_model_init_initialises_hsa_if_none(mocker):
     hsa_m.return_value = "hsa"
 
     # act
-    mdl = Model("aae", "arrivals", params, Mock(return_value="data"))  # type: ignore
+    data_loader = Mock()
+    mdl = Model("aae", "arrivals", params, data_loader)  # type: ignore
 
     # assert
-    hsa_m.assert_called_once_with("data", "2020", "2021", 1, 3)
+    hsa_m.assert_called_once_with(data_loader, "2020", "2021", 1, 3)
     assert mdl.hsa == "hsa"
 
 

--- a/tests/unit/nhp/model/test_model_iteration.py
+++ b/tests/unit/nhp/model/test_model_iteration.py
@@ -49,7 +49,7 @@ def test_init(mocker, run, rp_call):
     rng_mock.assert_called_once_with(1)
     prp_mock.assert_called_once_with()
     model._get_run_params.assert_called_once_with(rp_call)
-    actual._run.assert_called_once()  # type: ignore
+    actual._run.assert_called_once()
 
 
 @pytest.mark.unit

--- a/tests/unit/nhp/model/test_results.py
+++ b/tests/unit/nhp/model/test_results.py
@@ -448,3 +448,25 @@ def test_patch_converted_sdec_activity():
     actual = results["acuity"].sort_values(["pod", "sitetret", "measure", "acuity", "model_run"])
     # assert
     pd.testing.assert_frame_equal(actual, expected)
+
+
+@pytest.mark.unit
+def test_patch_converted_sdec_activity_noop_when_column_missing():
+    # arrange
+    default_df = pd.DataFrame(
+        {
+            "pod": ["aae_type-05"],
+            "sitetret": ["a"],
+            "measure": ["arrivals"],
+            "model_run": [1],
+            "value": [1],
+        }
+    )
+    results = {"default": default_df.copy()}
+
+    # act
+    _patch_converted_sdec_activity(results, "acuity", "standard")
+
+    # assert
+    assert set(results.keys()) == {"default"}
+    pd.testing.assert_frame_equal(results["default"], default_df)

--- a/tests/unit/nhp/model/test_run.py
+++ b/tests/unit/nhp/model/test_run.py
@@ -6,6 +6,7 @@ import pandas as pd
 import pytest
 
 from nhp.model.aae import AaEModel
+from nhp.model.data import Data
 from nhp.model.inpatients import InpatientsModel
 from nhp.model.outpatients import OutpatientsModel
 from nhp.model.run import (
@@ -134,7 +135,7 @@ def test_run_all(mocker):
         call(
             m,
             params,
-            data_mock,
+            "nhp_data",
             "hsa",
             {"variant": "variants"},
             pc_m(),
@@ -153,7 +154,7 @@ def test_run_single_model_run(mocker, capsys):
     # arrange
     mr_mock = Mock()
     ndl_mock = mocker.patch("nhp.model.run.Local")
-    ndl_mock.create.return_value = "nhp_data"
+    ndl_mock.return_value = "nhp_data"
 
     results_m = {
         "default": pd.DataFrame(
@@ -182,7 +183,7 @@ def test_run_single_model_run(mocker, capsys):
     run_single_model_run(params, "data", "model_type", 0)  # type: ignore
 
     # assert
-    ndl_mock.create.assert_called_once_with("data")
+    ndl_mock.assert_called_once_with("data", 2020, "synthetic")
 
     assert timeit_mock.call_count == 3
     assert timeit_mock.call_args_list[0] == call(
@@ -213,3 +214,53 @@ def test_run_single_model_run(mocker, capsys):
             "",
         ]
     )
+
+
+@pytest.mark.unit
+def test_run_all_uses_data_instance(mocker):
+    # arrange
+    grp_m = mocker.patch(
+        "nhp.model.run.Model.generate_run_params",
+        return_value={"variant": "variants"},
+    )
+    hsa_m = mocker.patch("nhp.model.run.HealthStatusAdjustmentInterpolated", return_value="hsa")
+    rm_m = mocker.patch("nhp.model.run._run_model", side_effect=["ip", "op", "aae"])
+    cr_m = mocker.patch("nhp.model.run.combine_results", return_value="combined_results")
+    pc_m = Mock()
+    pc_m().return_value = "progress callback"
+    pc_m.reset_mock()
+
+    params = {
+        "id": "1",
+        "dataset": "synthetic",
+        "scenario": "test",
+        "start_year": 2020,
+        "end_year": 2025,
+        "seed": 42,
+        "model_runs": 10,
+        "create_datetime": "20230123_012345",
+    }
+    nhp_data = Mock(spec=Data)
+
+    # act
+    actual = run_all(params, nhp_data, pc_m, False)
+
+    # assert
+    assert actual == ("combined_results", "variants")
+    grp_m.assert_called_once_with(params)
+    hsa_m.assert_called_once_with(nhp_data, 2020, 2025, 42, 10)
+    cr_m.assert_called_once_with(["ip", "op", "aae"])
+
+    assert rm_m.call_args_list == [
+        call(
+            m,
+            params,
+            nhp_data,
+            "hsa",
+            {"variant": "variants"},
+            pc_m(),
+            False,
+            None,
+        )
+        for m in [InpatientsModel, OutpatientsModel, AaEModel]
+    ]

--- a/tests/unit/nhp/model/test_run.py
+++ b/tests/unit/nhp/model/test_run.py
@@ -112,15 +112,17 @@ def test_run_all(mocker):
         "model_runs": 10,
         "create_datetime": "20230123_012345",
     }
-    data_mock = Mock(return_value="nhp_data")
+    nhp_data = Mock(spec=Data)
+    nhp_data.data_exists_for_model_type.side_effect = [True, True, True]
+    data_factory = Mock(return_value=nhp_data)
 
     # act
-    actual = run_all(params, data_mock, pc_m, False)
+    actual = run_all(params, data_factory, pc_m, False)
 
     # assert
     assert actual == ("combined_results", "variants")
 
-    data_mock.assert_called_once_with(2020, "synthetic")
+    data_factory.assert_called_once_with(2020, "synthetic")
 
     assert pc_m.call_args_list == [
         call("Inpatients"),
@@ -129,13 +131,13 @@ def test_run_all(mocker):
     ]
 
     grp_m.assert_called_once_with(params)
-    hsa_m.assert_called_once_with("nhp_data", 2020, 2025, 42, 10)
+    hsa_m.assert_called_once_with(nhp_data, 2020, 2025, 42, 10)
 
     assert rm_m.call_args_list == [
         call(
             m,
             params,
-            "nhp_data",
+            nhp_data,
             "hsa",
             {"variant": "variants"},
             pc_m(),
@@ -146,6 +148,69 @@ def test_run_all(mocker):
     ]
 
     cr_m.assert_called_once_with(["ip", "op", "aae"])
+
+
+@pytest.mark.unit
+def test_run_all_filters_model_types_by_available_data(mocker):
+    # arrange
+    grp_m = mocker.patch(
+        "nhp.model.run.Model.generate_run_params",
+        return_value={"variant": "variants"},
+    )
+    hsa_m = mocker.patch("nhp.model.run.HealthStatusAdjustmentInterpolated", return_value="hsa")
+    rm_m = mocker.patch("nhp.model.run._run_model", side_effect=["ip", "aae"])
+    cr_m = mocker.patch("nhp.model.run.combine_results", return_value="combined_results")
+
+    pc_m = Mock()
+    pc_m().return_value = "progress callback"
+    pc_m.reset_mock()
+
+    params = {
+        "id": "1",
+        "dataset": "synthetic",
+        "scenario": "test",
+        "start_year": 2020,
+        "end_year": 2025,
+        "seed": 42,
+        "model_runs": 10,
+        "create_datetime": "20230123_012345",
+    }
+
+    nhp_data = Mock(spec=Data)
+    nhp_data.data_exists_for_model_type.side_effect = [True, False, True]
+
+    # act
+    actual = run_all(params, nhp_data, pc_m, False)
+
+    # assert
+    assert actual == ("combined_results", "variants")
+    grp_m.assert_called_once_with(params)
+    hsa_m.assert_called_once_with(nhp_data, 2020, 2025, 42, 10)
+    cr_m.assert_called_once_with(["ip", "aae"])
+
+    assert pc_m.call_args_list == [call("Inpatients"), call("AaE")]
+    assert rm_m.call_args_list == [
+        call(
+            InpatientsModel,
+            params,
+            nhp_data,
+            "hsa",
+            {"variant": "variants"},
+            pc_m(),
+            False,
+            None,
+        ),
+        call(
+            AaEModel,
+            params,
+            nhp_data,
+            "hsa",
+            {"variant": "variants"},
+            pc_m(),
+            False,
+            None,
+        ),
+    ]
 
 
 @pytest.mark.unit


### PR DESCRIPTION
fixes #648

- **adds step to skip downloading data if it doesn't exist**
- **changes type of the data argument to model instances to be Data, not a callable**
- **adds method to test that files exist for a specified model type**
- **skips running a model type if data doesn't exist**
- **handles the edge case in sdec patching for providers without A&E data**
